### PR TITLE
Add camera exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently Frigate only supports notifications through Home Assistant, which I do
 - SMTP
 
 **Other**
-- Aliveness monitor via HTTP GET (for use with tools like [Uptime Kuma](https://github.com/louislam/uptime-kuma))
+- Aliveness monitor via HTTP GET (for use with tools like [HealthChecks](https://github.com/healthchecks/healthchecks) or [Uptime Kuma](https://github.com/louislam/uptime-kuma))
 
 ## Setup 
 
@@ -50,10 +50,10 @@ $ docker run -v /path/to/config.yml:/app/config.yml ghcr.io/0x2142/frigate-notif
 ## Future
 
 Just a quick list of things I may add later:
-- Ability to specify which cameras to alert on
 - Dampening time between notifications
 - Additional alerting methods
 
+> If you use this code & have any specific feature requests - please feel free to open an issue with the details of what you would like to see added
 
 ## Screenshots
 

--- a/config.go
+++ b/config.go
@@ -16,10 +16,11 @@ type Config struct {
 }
 
 type Frigate struct {
-	Server   string `yaml:"server"`
-	Insecure bool   `yaml:"ignoressl"`
-	WebAPI   WebAPI `yaml:"webapi"`
-	MQTT     MQTT   `yaml:"mqtt"`
+	Server   string  `yaml:"server"`
+	Insecure bool    `yaml:"ignoressl"`
+	WebAPI   WebAPI  `yaml:"webapi"`
+	MQTT     MQTT    `yaml:"mqtt"`
+	Cameras  Cameras `yaml:"cameras"`
 }
 
 type WebAPI struct {
@@ -33,6 +34,10 @@ type MQTT struct {
 	Port     int    `yaml:"port"`
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
+}
+
+type Cameras struct {
+	Exclude []string `yaml:"exclude"`
 }
 
 type Alerts struct {
@@ -136,6 +141,15 @@ func validateConfig() {
 		frigate.MQTTPort = ConfigData.Frigate.MQTT.Port
 		frigate.MQTTUser = ConfigData.Frigate.MQTT.Username
 		frigate.MQTTPass = ConfigData.Frigate.MQTT.Password
+	}
+
+	// Check for camera exclusions
+	if len(ConfigData.Frigate.Cameras.Exclude) > 0 {
+		log.Println("Cameras to exclude from alerting:")
+		for _, c := range ConfigData.Frigate.Cameras.Exclude {
+			log.Println(" -", c)
+		}
+		frigate.ExcludeCameras = ConfigData.Frigate.Cameras.Exclude
 	}
 
 	// Check / Load alerting configuration

--- a/events/api.go
+++ b/events/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/0x2142/frigate-notify/notifier"
 	"github.com/0x2142/frigate-notify/util"
+	"golang.org/x/exp/slices"
 )
 
 const eventsURI = "/api/events"
@@ -42,13 +43,19 @@ func CheckForEvents() {
 		// Convert to human-readable timestamp
 		eventTime := time.Unix(int64(event.StartTime), 0)
 
-		log.Printf("Event ID %v detected %v in zone(s): %v", event.ID, event.Label, event.Zones)
-		log.Println("Event Start time: ", eventTime)
-
 		// Update last event check time with most recent timestamp
 		if event.StartTime > LastEventTime {
 			LastEventTime = event.StartTime
 		}
+
+		// Skip excluded cameras
+		if slices.Contains(ExcludeCameras, event.Camera) {
+			log.Printf("Skipping event from excluded camera: %v", event.Camera)
+			continue
+		}
+
+		log.Printf("Event ID %v detected %v in zone(s): %v", event.ID, event.Label, event.Zones)
+		log.Println("Event Start time: ", eventTime)
 
 		// If snapshot was collected, pull down image to send with alert
 		var snapshot io.Reader

--- a/events/events.go
+++ b/events/events.go
@@ -29,6 +29,7 @@ type Event struct {
 
 var FrigateServerURL string
 var FrigateInsecure = false
+var ExcludeCameras []string
 
 // buildMessage constructs message payload for all alerting methods
 func buildMessage(time time.Time, event Event) string {

--- a/example-config.yml
+++ b/example-config.yml
@@ -25,9 +25,10 @@ frigate:
     password: 
   
   cameras:
-    # Exclude cameras from being monitored
+    # List of cameras to exclude from being monitored
     # Camera names must match frigate configuration
     exclude:
+      - test_cam_01
 
 
 ## Alerting methods

--- a/example-config.yml
+++ b/example-config.yml
@@ -23,6 +23,11 @@ frigate:
     # MQTT Authentication. Leave both blank for anonymous
     username: 
     password: 
+  
+  cameras:
+    # Exclude cameras from being monitored
+    # Camera names must match frigate configuration
+    exclude:
 
 
 ## Alerting methods

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 		log.Println("App Started.")
 		for {
 			frigate.CheckForEvents()
-			time.Sleep(30 * time.Second)
+			time.Sleep(time.Duration(ConfigData.Frigate.WebAPI.Interval) * time.Second)
 		}
 	}
 	// Connect MQTT


### PR DESCRIPTION
Added support for excluding cameras from alerting - to remove noise if not all cameras need to generate notifications.

Example config:

```yaml

  cameras:
    # List of cameras to exclude from being monitored
    # Camera names must match frigate configuration
    exclude:
      - test_cam_01
      - test_cam_02
```

Also includes minor adjustments to README & a fix for web API polling interval.

closes #2 