### PR TITLE
(fix) Allow SMTP without TLS

### DIFF
--- a/notifier/smtp.go
+++ b/notifier/smtp.go
@@ -36,9 +36,19 @@ func SendSMTP(message string, snapshot io.Reader) {
 
 	time.Sleep(5 * time.Second)
 
-	// Connect to SMTP server
-	c, err := mail.NewClient(SMTPServer, mail.WithPort(SMTPPort), mail.WithSMTPAuth(mail.SMTPAuthPlain),
-		mail.WithUsername(SMTPUser), mail.WithPassword(SMTPPassword))
+	// Set up SMTP Connection
+	c, err := mail.NewClient(SMTPServer, mail.WithPort(SMTPPort))
+	// Add authentication params if needed
+	if SMTPUser != "" && SMTPPassword != "" {
+		c.SetSMTPAuth(mail.SMTPAuthPlain)
+		c.SetUsername(SMTPUser)
+		c.SetPassword(SMTPPassword)
+	}
+	// Mandatory TLS is enabled by default, so disable TLS if config flag is set
+	if !SMTPTLS {
+		c.SetTLSPolicy(mail.NoTLS)
+	}
+
 	if err != nil {
 		log.Print("Failed to connect to SMTP Server: ", err)
 	}
@@ -46,6 +56,7 @@ func SendSMTP(message string, snapshot io.Reader) {
 	// Send message
 	if err := c.DialAndSend(m); err != nil {
 		log.Print("Failed to send SMTP message: ", err)
+		return
 	}
 	log.Println("SMTP alert sent")
 


### PR DESCRIPTION
Updated SMTP client for email alerting to use `NoTLS` if `SMTPTLS` config flag is set.

Should fix #16 