### PR TITLE
(fix) resolve issue with snapshot not working with multiple alert methods configured

### DIFF
--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -1,6 +1,7 @@
 package notifier
 
 import (
+	"bytes"
 	"io"
 )
 
@@ -11,13 +12,15 @@ var AlertTitle = "Frigate Alert"
 
 // SendAlert forwards alert information to all enabled alerting methods
 func SendAlert(message, snapshotURL string, snapshot io.Reader) {
+	// Create copy of snapshot for each alerting method
+	snap, _ := io.ReadAll(snapshot)
 	if DiscordEnabled {
-		SendDiscordMessage(message, snapshot)
+		SendDiscordMessage(message, bytes.NewReader(snap))
 	}
 	if GotifyEnabled {
 		SendGotifyPush(message, snapshotURL)
 	}
 	if SMTPEnabled {
-		SendSMTP(message, snapshot)
+		SendSMTP(message, bytes.NewReader(snap))
 	}
 }


### PR DESCRIPTION
Resolves an issue where Frigate snapshot wasn't being copied if multiple alert methods were configured. Only the first alert would get a copy of the screenshot.