### PR TITLE
Fixed crash if Frigate has no event info & app couldn't pull snapshots

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,15 +2,16 @@
 
 ## [v0.2.3](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.3) - Upcoming Release
 
-- Update config management
-- Improve config file validation
-- Fix issue where HTTP requests would fail if only IP & port were specified in config
+ - Updated config management
+ - Improved config file validation
+ - Fixed issue where HTTP requests would fail if only IP & port were specified in config
+ - Fixed crash if Frigate has no event info & app couldn't pull snapshots
 
 ## [v0.2.2](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.2) - Nov 29 2023
 
  - Fix SMTP issue where code was ignoring `tls: false` config flag
- - Fix issue where snapshots would only be sent to the first alerting method, if multiple were enabled 
- - Update Debian image used for Docker image 
+ - Fix issue where snapshots would only be sent to the first alerting method, if multiple were enabled
+ - Update Debian image used for Docker image
 
 ## [v0.2.1](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.1) - Sep 20 2023
 

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -80,7 +80,7 @@ func processEvent(client mqtt.Client, msg mqtt.Message) {
 		// If snapshot was collected, pull down image to send with alert
 		var snapshot io.Reader
 		var snapshotURL string
-		if !event.After.HasSnapshot {
+		if event.After.HasSnapshot {
 			snapshotURL = config.ConfigData.Frigate.Server + eventsURI + "/" + event.After.ID + snapshotURI
 			snapshot = GetSnapshot(snapshotURL, event.After.ID)
 		}

--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -10,7 +10,10 @@ import (
 // SendAlert forwards alert information to all enabled alerting methods
 func SendAlert(message, snapshotURL string, snapshot io.Reader) {
 	// Create copy of snapshot for each alerting method
-	snap, _ := io.ReadAll(snapshot)
+	var snap []byte
+	if snapshot != nil {
+		snap, _ = io.ReadAll(snapshot)
+	}
 	if config.ConfigData.Alerts.Discord.Enabled {
 		SendDiscordMessage(message, bytes.NewReader(snap))
 	}


### PR DESCRIPTION
Reported in #24 - App would crash if a snapshot wasn't included.

This double-checks that snapshot is not `nil` before attempting to read it.