### PR TITLE
Add gh-pages CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+frigate-notify.0x2142.com


### PR DESCRIPTION
GitHub pages was overwriting custom CNAME for docs on every deploy. Turns out it needs a custom `CNAME` file in the docs root to prevent this. Adding that file here... 