### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:bookworm
+FROM golang:1.22-alpine as build
 
 WORKDIR /app
 
@@ -9,6 +9,12 @@ RUN go mod download
 
 COPY . /app/
 
-RUN go build -o /app/frigate-notify .
+RUN go build -o /frigate-notify .
+
+FROM scratch
+
+WORKDIR /app
+
+COPY --from=build /frigate-notify /app/frigate-notify
 
 ENTRYPOINT [ "/app/frigate-notify" ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## [v0.2.5](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.5) - TBD
+## [v0.2.5](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.5) - Mar 29 2024
 
  - Added support for alerts via [Pushover](https://frigate-notify.0x2142.com/config/#pushover)
+ - Reduced container image from ~1Gb to ~11Mb
 
 ## [v0.2.4](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.4) - Mar 28 2024
 


### PR DESCRIPTION
Revised docker build to include multistage build. 

This reduced the container size from around 1Gb to ~11Mb. 