### PR TITLE
Fix zone issue

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-buy_me_a_coffee: 0x2142

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY go.mod /app/
 COPY go.sum /app/
 
+RUN apk --no-cache add tzdata ca-certificates
 RUN go mod download
 
 COPY . /app/
@@ -16,6 +17,7 @@ FROM scratch
 WORKDIR /app
 
 COPY --from=build /frigate-notify /app/frigate-notify
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT [ "/app/frigate-notify" ]

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,8 @@ type Alerts struct {
 }
 
 type General struct {
-	Title string `fig:"title" default:"Frigate Alert"`
+	Title      string `fig:"title" default:"Frigate Alert"`
+	TimeFormat string `fig:"timeformat" default: ""`
 }
 
 type Zones struct {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.0"
 services:
   frigate-notify:
     image: ghcr.io/0x2142/frigate-notify:latest
+    environment:
+      - TZ=Etc/UTC
     volumes:
       - /path/to/config:/app/config
     restart: unless-stopped

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.2.6](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.6) - Apr 01 2024
+
+ - Fixed issue with setting `unzoned: drop` under zone config, where alerts wouldn't be sent if event began outside a zone.
+ - Fixed issue with correct timezone getting applied on container image
+ - Added `timeformat` option for notifications, which allows custom date/time format
+ - Minor updates to logging to ensure all event logs have an event ID attached
+
 ## [v0.2.5](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.5) - Mar 29 2024
 
  - Added support for alerts via [Pushover](https://frigate-notify.0x2142.com/config/#pushover)

--- a/docs/config.md
+++ b/docs/config.md
@@ -94,11 +94,17 @@ frigate:
 
 - **title** (Optional - Default: `Frigate Alert`)
     - Title of alert messages that are generated (Email subject, etc)
+- **timeformat** (Optional - Default: `2006-01-02 15:04:05 -0700 MST`)
+    - Optionally set a custom date/time format for notifications
+    - This utilizes Golang's [reference time](https://go.dev/src/time/format.go) for formatting
+    - See [this](https://www.geeksforgeeks.org/time-formatting-in-golang) guide for help
+    - Example below uses RFC1123 format
 
 ```yaml title="Config File Snippet"
 alerts:  
   general:
     title: Frigate Alert
+    timeformat: Mon, 02 Jan 2006 15:04:05 MST
 ```
 
 ### Zones
@@ -338,6 +344,7 @@ frigate:
 alerts:  
   general:
     title:
+    timeformat:
 
   zones:
     unzoned: allow

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,11 +11,14 @@ The app can be run as a container with the bundled [docker-compose.yml](https://
 ```yaml
 version: "3.0"
 services:
-    frigate-notify:
+  frigate-notify:
     image: ghcr.io/0x2142/frigate-notify:latest
+    environment:
+      - TZ=Etc/UTC
     volumes:
-        - /path/to/config:/app/config
+      - /path/to/config:/app/config
     restart: unless-stopped
+
 ```
 
 Update `volumes` in the compose file to the location of the `config.yml` file. By default the app will check the `/app/config` directory for this file.

--- a/events/api.go
+++ b/events/api.go
@@ -80,7 +80,7 @@ func CheckForEvents() {
 		message := buildMessage(eventTime, event)
 
 		// Send alert with snapshot
-		notifier.SendAlert(message, snapshotURL, snapshot)
+		notifier.SendAlert(message, snapshotURL, snapshot, event.ID)
 	}
 
 }

--- a/events/api.go
+++ b/events/api.go
@@ -57,7 +57,7 @@ func CheckForEvents() {
 
 		// Skip excluded cameras
 		if slices.Contains(config.ConfigData.Frigate.Cameras.Exclude, event.Camera) {
-			log.Printf("Skipping event from excluded camera: %v", event.Camera)
+			log.Printf("Event ID %v - Skipping event from excluded camera: %v", event.ID, event.Camera)
 			continue
 		}
 

--- a/events/events.go
+++ b/events/events.go
@@ -31,6 +31,7 @@ type Event struct {
 	TopScore           float64     `json:"top_score"`
 	Zones              []string    `json:"zones"`
 	CurrentZones       []string    `json:"current_zones"`
+	EnteredZones       []string    `json:"entered_zones"`
 }
 
 // buildMessage constructs message payload for all alerting methods

--- a/events/events.go
+++ b/events/events.go
@@ -36,8 +36,13 @@ type Event struct {
 
 // buildMessage constructs message payload for all alerting methods
 func buildMessage(time time.Time, event Event) string {
+	// If certain time format is provided, re-format date / time string
+	timestr := time.String()
+	if config.ConfigData.Alerts.General.TimeFormat != "" {
+		timestr = time.Format(config.ConfigData.Alerts.General.TimeFormat)
+	}
 	// Build alert message payload, include two spaces at end to force markdown newline
-	message := fmt.Sprintf("Detection at %v  ", time)
+	message := fmt.Sprintf("Detection at %v  ", timestr)
 	message += fmt.Sprintf("\nCamera: %s  ", event.Camera)
 	// Attach detection label & caculate score percentage
 	message += fmt.Sprintf("\nLabel: %v (%v%%)  ", event.Label, int((event.TopScore * 100)))
@@ -54,7 +59,7 @@ func buildMessage(time time.Time, event Event) string {
 	// If event has a recorded clip, include a link to that as well
 	if event.HasClip {
 		message += " | "
-		message += fmt.Sprintf("[Event Clip](%s/api/events/%s/clip.mp4)", config.ConfigData.Frigate.Server, event.ID)
+		message += fmt.Sprintf("[Event Clip](%s/api/events/%s/clip.mp4)  ", config.ConfigData.Frigate.Server, event.ID)
 	}
 
 	return message

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -65,7 +65,11 @@ func processEvent(client mqtt.Client, msg mqtt.Message) {
 	json.Unmarshal(msg.Payload(), &event)
 
 	if event.Type == "new" || event.Type == "update" {
-		log.Printf("Event ID %v - %v", event.After.ID, event.Type)
+		if event.Type == "new" {
+			log.Printf("Event ID %v - New event received.", event.After.ID)
+		} else if event.Type == "update" {
+			log.Printf("Event ID %v - Event updated from Frigate.", event.After.ID)
+		}
 		// Skip excluded cameras
 		if slices.Contains(config.ConfigData.Frigate.Cameras.Exclude, event.After.Camera) {
 			log.Printf("Skipping event from excluded camera: %v", event.After.Camera)

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -65,7 +65,7 @@ func processEvent(client mqtt.Client, msg mqtt.Message) {
 	json.Unmarshal(msg.Payload(), &event)
 
 	if event.Type == "new" || event.Type == "update" {
-		fmt.Printf("Event ID %v - %v", event.After.ID, event.Type)
+		log.Printf("Event ID %v - %v", event.After.ID, event.Type)
 		// Skip excluded cameras
 		if slices.Contains(config.ConfigData.Frigate.Cameras.Exclude, event.After.Camera) {
 			log.Printf("Skipping event from excluded camera: %v", event.After.Camera)

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -72,7 +72,7 @@ func processEvent(client mqtt.Client, msg mqtt.Message) {
 		}
 		// Skip excluded cameras
 		if slices.Contains(config.ConfigData.Frigate.Cameras.Exclude, event.After.Camera) {
-			log.Printf("Skipping event from excluded camera: %v", event.After.Camera)
+			log.Printf("Event ID %v - Skipping event from excluded camera: %v", event.After.ID, event.After.Camera)
 			return
 		}
 

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -107,7 +107,7 @@ func processEvent(client mqtt.Client, msg mqtt.Message) {
 		message := buildMessage(eventTime, event.After.Event)
 
 		// Send alert with snapshot
-		notifier.SendAlert(message, snapshotURL, snapshot)
+		notifier.SendAlert(message, snapshotURL, snapshot, event.After.ID)
 	}
 }
 

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -65,6 +65,7 @@ func processEvent(client mqtt.Client, msg mqtt.Message) {
 	json.Unmarshal(msg.Payload(), &event)
 
 	if event.Type == "new" || event.Type == "update" {
+		fmt.Printf("Event ID %v - %v", event.After.ID, event.Type)
 		// Skip excluded cameras
 		if slices.Contains(config.ConfigData.Frigate.Cameras.Exclude, event.After.Camera) {
 			log.Printf("Skipping event from excluded camera: %v", event.After.Camera)

--- a/example-config.yml
+++ b/example-config.yml
@@ -43,6 +43,9 @@ alerts:
   general:
     # Title for any alert messages (Default: Frigate Alert)
     title:
+    # Optionally modify default time format in notifications
+    # Use Golang's reference time format, or see docs for more info
+    timeformat:
 
   zones:
     # Allow notifications for events outside a zone

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/0x2142/frigate-notify/config"
 	frigate "github.com/0x2142/frigate-notify/events"

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/0x2142/frigate-notify/util"
 )
 
-var APP_VER = "v0.2.5"
+var APP_VER = "v0.2.6"
 
 func main() {
 	log.Println("Frigate Notify -", APP_VER)

--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -8,25 +8,25 @@ import (
 )
 
 // SendAlert forwards alert information to all enabled alerting methods
-func SendAlert(message, snapshotURL string, snapshot io.Reader) {
+func SendAlert(message, snapshotURL string, snapshot io.Reader, eventid string) {
 	// Create copy of snapshot for each alerting method
 	var snap []byte
 	if snapshot != nil {
 		snap, _ = io.ReadAll(snapshot)
 	}
 	if config.ConfigData.Alerts.Discord.Enabled {
-		SendDiscordMessage(message, bytes.NewReader(snap))
+		SendDiscordMessage(message, bytes.NewReader(snap), eventid)
 	}
 	if config.ConfigData.Alerts.Gotify.Enabled {
-		SendGotifyPush(message, snapshotURL)
+		SendGotifyPush(message, snapshotURL, eventid)
 	}
 	if config.ConfigData.Alerts.SMTP.Enabled {
-		SendSMTP(message, bytes.NewReader(snap))
+		SendSMTP(message, bytes.NewReader(snap), eventid)
 	}
 	if config.ConfigData.Alerts.Telegram.Enabled {
-		SendTelegramMessage(message, bytes.NewReader(snap))
+		SendTelegramMessage(message, bytes.NewReader(snap), eventid)
 	}
 	if config.ConfigData.Alerts.Pushover.Enabled {
-		SendPushoverMessage(message, bytes.NewReader(snap))
+		SendPushoverMessage(message, bytes.NewReader(snap), eventid)
 	}
 }

--- a/notifier/discord.go
+++ b/notifier/discord.go
@@ -18,7 +18,7 @@ func SendDiscordMessage(message string, snapshot io.Reader, eventid string) {
 	// Connect to Discord
 	client, err := webhook.NewWithURL(config.ConfigData.Alerts.Discord.Webhook)
 	if err != nil {
-		log.Printf("Unable to send Discord Alert: %v", err)
+		log.Printf("Event ID %v - Unable to send Discord Alert: %v", eventid, err)
 	}
 	defer client.Close(context.TODO())
 
@@ -37,7 +37,7 @@ func SendDiscordMessage(message string, snapshot io.Reader, eventid string) {
 
 	}
 	if err != nil {
-		log.Printf("Unable to send Discord Alert: %v", err)
+		log.Printf("Event ID %v - Unable to send Discord Alert: %v", eventid, err)
 	}
 	log.Printf("Event ID %v - Discord alert sent", eventid)
 }

--- a/notifier/discord.go
+++ b/notifier/discord.go
@@ -12,7 +12,7 @@ import (
 )
 
 // SendDiscordMessage pushes alert message to Discord via webhook
-func SendDiscordMessage(message string, snapshot io.Reader) {
+func SendDiscordMessage(message string, snapshot io.Reader, eventid string) {
 	var err error
 
 	// Connect to Discord
@@ -39,5 +39,5 @@ func SendDiscordMessage(message string, snapshot io.Reader) {
 	if err != nil {
 		log.Printf("Unable to send Discord Alert: %v", err)
 	}
-	log.Println("Discord alert sent")
+	log.Printf("Event ID %v - Discord alert sent", eventid)
 }

--- a/notifier/gotify.go
+++ b/notifier/gotify.go
@@ -33,7 +33,7 @@ type gotifyPayload struct {
 }
 
 // SendGotifyPush forwards alert messages to Gotify push notification server
-func SendGotifyPush(message, snapshotURL string) {
+func SendGotifyPush(message, snapshotURL string, eventid string) {
 	if snapshotURL != "" {
 		message += fmt.Sprintf("\n\n![](%s)", snapshotURL)
 	} else {
@@ -67,5 +67,5 @@ func SendGotifyPush(message, snapshotURL string) {
 		log.Printf("Failed to send Gotify notification: %s - %s", errorMessage.Error, errorMessage.ErrorDescription)
 		return
 	}
-	log.Print("Gotify message sent")
+	log.Printf("Event ID %v - Gotify alert sent", eventid)
 }

--- a/notifier/gotify.go
+++ b/notifier/gotify.go
@@ -49,7 +49,7 @@ func SendGotifyPush(message, snapshotURL string, eventid string) {
 
 	data, err := json.Marshal(payload)
 	if err != nil {
-		log.Println("Unable to build Gotify payload: ", err)
+		log.Println("Event ID %v - Unable to build Gotify payload: ", eventid, err)
 		return
 	}
 
@@ -64,7 +64,7 @@ func SendGotifyPush(message, snapshotURL string, eventid string) {
 	if strings.Contains(string(response), "error") {
 		var errorMessage gotifyError
 		json.Unmarshal(response, &errorMessage)
-		log.Printf("Failed to send Gotify notification: %s - %s", errorMessage.Error, errorMessage.ErrorDescription)
+		log.Printf("Event ID %v - Failed to send Gotify notification: %s - %s", eventid, errorMessage.Error, errorMessage.ErrorDescription)
 		return
 	}
 	log.Printf("Event ID %v - Gotify alert sent", eventid)

--- a/notifier/pushover.go
+++ b/notifier/pushover.go
@@ -47,12 +47,12 @@ func SendPushoverMessage(message string, snapshot io.Reader, eventid string) {
 	if snapshot != nil {
 		notif.AddAttachment(snapshot)
 		if _, err := push.SendMessage(notif, recipient); err != nil {
-			log.Print("Error sending Pushover notification:", err)
+			log.Print("Event ID %v - Error sending Pushover notification:", eventid, err)
 			return
 		}
 	} else {
 		if _, err := push.SendMessage(notif, recipient); err != nil {
-			log.Print("Error sending Pushover notification:", err)
+			log.Print("Event ID %v - Error sending Pushover notification:", eventid, err)
 			return
 		}
 	}

--- a/notifier/pushover.go
+++ b/notifier/pushover.go
@@ -13,7 +13,7 @@ import (
 )
 
 // SendPushoverMessage sends alert message through Pushover service
-func SendPushoverMessage(message string, snapshot io.Reader) {
+func SendPushoverMessage(message string, snapshot io.Reader, eventid string) {
 	push := pushover.New(config.ConfigData.Alerts.Pushover.Token)
 	recipient := pushover.NewRecipient(config.ConfigData.Alerts.Pushover.Userkey)
 
@@ -57,5 +57,5 @@ func SendPushoverMessage(message string, snapshot io.Reader) {
 		}
 	}
 
-	log.Println("Pushover alert sent")
+	log.Printf("Event ID %v - Pushover alert sent", eventid)
 }

--- a/notifier/smtp.go
+++ b/notifier/smtp.go
@@ -44,12 +44,12 @@ func SendSMTP(message string, snapshot io.Reader, eventid string) {
 	}
 
 	if err != nil {
-		log.Print("Failed to connect to SMTP Server: ", err)
+		log.Print("Event ID %v - Failed to connect to SMTP Server: ", eventid, err)
 	}
 
 	// Send message
 	if err := c.DialAndSend(m); err != nil {
-		log.Print("Failed to send SMTP message: ", err)
+		log.Print("Event ID %v - Failed to send SMTP message: ", eventid, err)
 		return
 	}
 	log.Printf("Event ID %v - SMTP alert sent", eventid)

--- a/notifier/smtp.go
+++ b/notifier/smtp.go
@@ -12,7 +12,7 @@ import (
 )
 
 // SendSMTP forwards alert data via email
-func SendSMTP(message string, snapshot io.Reader) {
+func SendSMTP(message string, snapshot io.Reader, eventid string) {
 	// Set up email alert
 	m := mail.NewMsg()
 	m.From(config.ConfigData.Alerts.SMTP.User)
@@ -52,7 +52,7 @@ func SendSMTP(message string, snapshot io.Reader) {
 		log.Print("Failed to send SMTP message: ", err)
 		return
 	}
-	log.Println("SMTP alert sent")
+	log.Printf("Event ID %v - SMTP alert sent", eventid)
 
 }
 

--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -14,7 +14,7 @@ import (
 func SendTelegramMessage(message string, snapshot io.Reader, eventid string) {
 	bot, err := tgbotapi.NewBotAPI(config.ConfigData.Alerts.Telegram.Token)
 	if err != nil {
-		log.Print("Failed to connect to Telegram:", err)
+		log.Print("Event ID %v - Failed to connect to Telegram:", eventid, err)
 		return
 	}
 
@@ -30,7 +30,7 @@ func SendTelegramMessage(message string, snapshot io.Reader, eventid string) {
 		photo.Caption = htmlMessage
 		photo.ParseMode = "HTML"
 		if _, err := bot.Send(photo); err != nil {
-			log.Print("Failed to send alert via Telegram:", err)
+			log.Print("Event ID %v - Failed to send alert via Telegram:", eventid, err)
 			return
 		}
 	} else {
@@ -39,7 +39,7 @@ func SendTelegramMessage(message string, snapshot io.Reader, eventid string) {
 		msg := tgbotapi.NewMessage(config.ConfigData.Alerts.Telegram.ChatID, htmlMessage)
 		msg.ParseMode = "HTML"
 		if _, err := bot.Send(msg); err != nil {
-			log.Print("Failed to send alert via Telegram:", err)
+			log.Print("Event ID %v - Failed to send alert via Telegram:", eventid, err)
 			return
 		}
 	}

--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SendTelegramMessage sends alert through Telegram to individual users
-func SendTelegramMessage(message string, snapshot io.Reader) {
+func SendTelegramMessage(message string, snapshot io.Reader, eventid string) {
 	bot, err := tgbotapi.NewBotAPI(config.ConfigData.Alerts.Telegram.Token)
 	if err != nil {
 		log.Print("Failed to connect to Telegram:", err)
@@ -43,5 +43,5 @@ func SendTelegramMessage(message string, snapshot io.Reader) {
 			return
 		}
 	}
-	log.Println("Telegram alert sent")
+	log.Printf("Event ID %v - Telegram alert sent", eventid)
 }


### PR DESCRIPTION
This PR fixes issues with the zone filter raised in #37. Originally, this was built to only alert on new events from Frigate. However, Frigate will send updated event notifications to MQTT upon certain things, like the detected object moving to a different zone. 

So with the zone filter built as it was originally, the app would only send an event if there was a **new** event that contained a zone. If an event started with no zone info, and was updated later, no notification would be sent. App code adjusted to account for event updates, and compare zone details. New alerts will only be sent if the object enters a new zone & also that zone is on the allowed notification list. 

Also added the ability to provide custom date / time formats to be used in the notifications. And cleaned up some logs to ensure that all event-related logs should have the event ID attached.