### PR TITLE
Allow changing default MQTT topic prefix via config (#41)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,12 +31,13 @@ type WebAPI struct {
 }
 
 type MQTT struct {
-	Enabled  bool   `fig:"enabled" default:false`
-	Server   string `fig:"server" default:""`
-	Port     int    `fig:"port" default:1883`
-	ClientID string `fig:"clientid" default:"frigate-notify"`
-	Username string `fig:"username" default:""`
-	Password string `fig:"password" default:""`
+	Enabled     bool   `fig:"enabled" default:false`
+	Server      string `fig:"server" default:""`
+	Port        int    `fig:"port" default:1883`
+	ClientID    string `fig:"clientid" default:"frigate-notify"`
+	Username    string `fig:"username" default:""`
+	Password    string `fig:"password" default:""`
+	TopicPrefix string `fig:"topic_prefix" default:"frigate"`
 }
 
 type Cameras struct {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.2.7](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.7) - TBD
+
+- Allow changing default MQTT topic prefix via config
+
 ## [v0.2.6](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.6) - Apr 01 2024
 
  - Fixed issue with setting `unzoned: drop` under zone config, where alerts wouldn't be sent if event began outside a zone.

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,9 @@ frigate:
 - **password** (Optional)
     - MQTT password
     - Required if `username` is set
+- **topic_prefix** (Optional - Default: `frigate`)
+    - Optionally change MQTT topic prefix
+    - This should match the topic prefix used by Frigate
 
 ```yaml title="Config File Snippet"
 frigate:
@@ -68,6 +71,7 @@ frigate:
     clientid: frigate-notify
     username: mqtt-user
     password: mqtt-pass
+    topic_prefix: frigate
 ```
 
 ### Cameras
@@ -345,6 +349,7 @@ frigate:
     clientid:
     username: 
     password: 
+    topic_prefix: 
   
   cameras:
     exclude:

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -60,6 +60,7 @@ func SubscribeMQTT() {
 
 // processEvent handles incoming MQTT messages & pulls out relevant info for alerting
 func processEvent(client mqtt.Client, msg mqtt.Message) {
+	fmt.Println("GOT MQTT")
 	// Parse incoming MQTT message
 	var event MQTTEvent
 	json.Unmarshal(msg.Payload(), &event)
@@ -124,9 +125,10 @@ func connectionLostHandler(c mqtt.Client, err error) {
 // connectHandler logs message on MQTT connection
 func connectHandler(client mqtt.Client) {
 	log.Println("Connected to MQTT.")
-	if subscription := client.Subscribe("frigate/events", 0, processEvent); subscription.Wait() && subscription.Error() != nil {
-		log.Printf("Failed to subscribe to topic frigate/events")
+	topic := fmt.Sprintf(config.ConfigData.Frigate.MQTT.TopicPrefix + "/events")
+	if subscription := client.Subscribe(topic, 0, processEvent); subscription.Wait() && subscription.Error() != nil {
+		log.Printf("Failed to subscribe to topic: %s", topic)
 		time.Sleep(10 * time.Second)
 	}
-	log.Printf("Subscribed to MQTT topic frigate/events")
+	log.Printf("Subscribed to MQTT topic: %s", topic)
 }

--- a/example-config.yml
+++ b/example-config.yml
@@ -28,6 +28,8 @@ frigate:
     # MQTT Authentication. Leave both blank for anonymous
     username: 
     password: 
+    # Optionally set custom topic prefix (Default: frigate)
+    topic_prefix: 
   
   cameras:
     # List of cameras to exclude from being monitored


### PR DESCRIPTION
Add new `topic_prefix` config item under frigate > mqtt. This overrides the default `frigate` MQTT topic. 

Events are subscribed at `<topic_prefix>/events`

Original Request: #41 