### PR TITLE
Add label filtering

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type Cameras struct {
 type Alerts struct {
 	General  General  `fig:"general"`
 	Zones    Zones    `fig:"zones"`
+	Labels   Labels   `fig:"labels"`
 	Discord  Discord  `fig:"discord"`
 	Gotify   Gotify   `fig:"gotify"`
 	SMTP     SMTP     `fig:"smtp"`
@@ -63,6 +64,11 @@ type Zones struct {
 	Unzoned string   `fig:"unzoned" default:"allow"`
 	Allow   []string `fig:"allow" default:[]`
 	Block   []string `fig:"block" default:[]`
+}
+
+type Labels struct {
+	Allow []string `fig:"allow" default:[]`
+	Block []string `fig:"block" default:[]`
 }
 
 type Discord struct {
@@ -184,7 +190,7 @@ func validateConfig() {
 		}
 	}
 
-	// Check Zone config
+	// Check Zone filtering config
 	if strings.ToLower(ConfigData.Alerts.Zones.Unzoned) != "allow" && strings.ToLower(ConfigData.Alerts.Zones.Unzoned) != "drop" {
 		configErrors = append(configErrors, "Option for unzoned events must be 'allow' or 'drop'")
 	} else {
@@ -206,6 +212,24 @@ func validateConfig() {
 		}
 	} else {
 		log.Println("No zones excluded")
+	}
+
+	// Check Label filtering config
+	if len(ConfigData.Alerts.Labels.Allow) > 0 {
+		log.Println("Labels to generate alerts for:")
+		for _, c := range ConfigData.Alerts.Labels.Allow {
+			log.Println(" -", c)
+		}
+	} else {
+		log.Println("All labels included in alerts")
+	}
+	if len(ConfigData.Alerts.Labels.Block) > 0 {
+		log.Println("Labels to exclude from alerting:")
+		for _, c := range ConfigData.Alerts.Labels.Block {
+			log.Println(" -", c)
+		}
+	} else {
+		log.Println("No labels excluded")
 	}
 
 	// Check / Load alerting configuration

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,9 @@
 ## [v0.2.7](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.7) - TBD
 
 - Allow changing default MQTT topic prefix via config
+- Added ability to filter notifications based on [labels](https://frigate-notify.0x2142.com/config/#labels)
+    - New option to allow only notifications with specified labels
+    - New option to deny notifications based on labels
 
 ## [v0.2.6](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.6) - Apr 01 2024
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.2.7](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.7) - TBD
+## [v0.2.7](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.7) - May 06 2024
 
 - Allow changing default MQTT topic prefix via config
 - Added ability to filter notifications based on [labels](https://frigate-notify.0x2142.com/config/#labels)

--- a/docs/config.md
+++ b/docs/config.md
@@ -147,6 +147,28 @@ alerts:
      - test_zone_02
 ```
 
+### Labels
+
+Similar to [zones](#zones), notifications can be filtered based on labels. By default, the app will generate notifications regardless of any labels received from Frigate. Using this config section, certain labels can be blocked from sending notifications - or an allowlist can be provided to only generate alerts from specified labels.
+
+- **allow** (Optional)
+    - Specify a list of labels to allow notifications
+    - If set, all other labels will be ignored
+    - If not set, all labels will generate notifications
+- **block** (Optional)
+    - Specify a list of labels to always ignore
+    - This takes precedence over the `allow` list
+
+```yaml title="Config File Snippet"
+alerts:
+  labels:
+    allow:
+     - person
+     - dog
+    block:
+     - bird
+```
+
 ### Discord
 
 - **enabled** (Optional - Default: `false`)

--- a/events/api.go
+++ b/events/api.go
@@ -64,8 +64,8 @@ func CheckForEvents() {
 		log.Printf("Event ID %v - Camera %v detected %v in zone(s): %v", event.ID, event.Camera, event.Label, event.Zones)
 		log.Printf("Event ID %v - Start time: %s", event.ID, eventTime)
 
-		// Check that event passes the zone filter
-		if !isAllowedZone(event.ID, event.Zones) {
+		// Check that event passes the zone & label filters
+		if !isAllowedZone(event.ID, event.Zones) || !isAllowedLabel(event.ID, event.Label) {
 			return
 		}
 

--- a/events/events.go
+++ b/events/events.go
@@ -92,6 +92,27 @@ func isAllowedZone(id string, zones []string) bool {
 		}
 	}
 	// Default drop event
-	log.Printf("Event ID %v - Dropped. Not on allow list.", id)
+	log.Printf("Event ID %v - Dropped. Not on zone allow list.", id)
+	return false
+}
+
+// isAllowedLabel verifies whether a label should be allowed to generate a notification
+func isAllowedLabel(id string, label string) bool {
+	// Check label block list
+	if slices.Contains(config.ConfigData.Alerts.Labels.Block, label) {
+		log.Printf("Event ID %v - Dropped by label block list.", id)
+		return false
+	}
+	// If no allow list, all events are permitted
+	if len(config.ConfigData.Alerts.Labels.Allow) == 0 {
+		return true
+	}
+	// Check label allow list
+	if slices.Contains(config.ConfigData.Alerts.Labels.Allow, label) {
+		return true
+	}
+
+	// Default drop event
+	log.Printf("Event ID %v - Dropped. Not on label allow list.", id)
 	return false
 }

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -60,7 +60,6 @@ func SubscribeMQTT() {
 
 // processEvent handles incoming MQTT messages & pulls out relevant info for alerting
 func processEvent(client mqtt.Client, msg mqtt.Message) {
-	fmt.Println("GOT MQTT")
 	// Parse incoming MQTT message
 	var event MQTTEvent
 	json.Unmarshal(msg.Payload(), &event)
@@ -83,8 +82,8 @@ func processEvent(client mqtt.Client, msg mqtt.Message) {
 		log.Printf("Event ID %v - Camera %v detected %v in zone(s): %v", event.After.ID, event.After.Camera, event.After.Label, event.After.CurrentZones)
 		log.Printf("Event ID %v - Start time: %s", event.After.ID, eventTime)
 
-		// Check that event passes the zone filter
-		if !isAllowedZone(event.After.ID, event.After.CurrentZones) {
+		// Check that event passes the zone & label filters
+		if !isAllowedZone(event.After.ID, event.After.CurrentZones) || !isAllowedLabel(event.After.ID, event.After.Label) {
 			return
 		}
 

--- a/example-config.yml
+++ b/example-config.yml
@@ -61,6 +61,12 @@ alerts:
     block:
      - test_zone_02
 
+  labels:
+    # Filter notifications to only specific labels allowed here
+    allow:
+    # List of labels to never generate notifications
+    block:
+
   discord:
     # Set to true to enable alerting via Discord messages
     enabled: false

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/0x2142/frigate-notify/util"
 )
 
-var APP_VER = "v0.2.6"
+var APP_VER = "v0.2.7"
 
 func main() {
 	log.Println("Frigate Notify -", APP_VER)


### PR DESCRIPTION
Adds new event filtering based on detection label. Implementation similar to zone filtering. 

New config section to `allow` or `block` labels. 

- Allow acts as permit filter. If left empty, labels are not checked & events are sent. If specified, only configured labels will generate alerts. 
- Block list will always filter any listed labels, even if permitted by allow list

Also bump app version to v0.2.7 for release

Original request: #40 