### PR TITLE
Add label config to sample config in docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -390,6 +390,13 @@ alerts:
     block:
      - test_zone_02
 
+  labels:
+    allow:
+     - person
+     - dog
+    block:
+     - bird
+
   discord:
     enabled: false
     webhook: 


### PR DESCRIPTION
Quick update to empty sample config file in docs - add label allow/block section that was just introduced.