### PR TITLE
Add frigate auth headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type Alerts struct {
 	SMTP     SMTP     `fig:"smtp"`
 	Telegram Telegram `fig:"telegram"`
 	Pushover Pushover `fig:"pushover"`
+	Nfty     Nfty     `fig:"nfty"`
 }
 
 type General struct {
@@ -108,6 +109,13 @@ type Pushover struct {
 	Retry    int    `fig:"retry" default:0`
 	Expire   int    `fig:"expire" default:0`
 	TTL      int    `fig:"ttl" default:0`
+}
+
+type Nfty struct {
+	Enabled  bool   `fig:"enabled" default:false`
+	Server   string `fig:"server" default:""`
+	Topic    string `fig:"topic" default:""`
+	Insecure bool   `fig:"ignoressl" default:false`
 }
 
 type Monitor struct {
@@ -300,6 +308,16 @@ func validateConfig() {
 		if ConfigData.Alerts.Pushover.TTL < 0 {
 			configErrors = append(configErrors, "Pushover TTL cannot be negative!")
 		}
+	}
+	if ConfigData.Alerts.Nfty.Enabled {
+		log.Print("Nfty alerting enabled.")
+		if ConfigData.Alerts.Nfty.Server == "" {
+			configErrors = append(configErrors, "No Nfty server specified!")
+		}
+		if ConfigData.Alerts.Nfty.Topic == "" {
+			configErrors = append(configErrors, "No Nfty topic specified!")
+		}
+
 	}
 
 	// Validate monitoring config

--- a/config/config.go
+++ b/config/config.go
@@ -17,11 +17,12 @@ type Config struct {
 }
 
 type Frigate struct {
-	Server   string  `fig:"server" validate:"required"`
-	Insecure bool    `fig:"ignoressl" default:false`
-	WebAPI   WebAPI  `fig:"webapi"`
-	MQTT     MQTT    `fig:"mqtt"`
-	Cameras  Cameras `fig:"cameras"`
+	Server   string              `fig:"server" validate:"required"`
+	Insecure bool                `fig:"ignoressl" default:false`
+	Headers  []map[string]string `fig:"headers"`
+	WebAPI   WebAPI              `fig:"webapi"`
+	MQTT     MQTT                `fig:"mqtt"`
+	Cameras  Cameras             `fig:"cameras"`
 }
 
 type WebAPI struct {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## [v0.2.8](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.8) - Upcoming Release
 
 - Add support for notifications via [Nfty](https://frigate-notify.0x2142.com/config/#nfty)
+- Add ability to send additional HTTP [headers](https://frigate-notify.0x2142.com/config/#frigate) to Frigate
 
 ## [v0.2.7](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.7) - May 06 2024
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.2.8](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.8) - Upcoming Release
+
+- Add support for notifications via [Nfty](https://frigate-notify.0x2142.com/config/#nfty)
+
 ## [v0.2.7](https://github.com/0x2142/frigate-notify/releases/tag/v0.2.7) - May 06 2024
 
 - Allow changing default MQTT topic prefix via config

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,11 +12,18 @@ Configuration snippets will be provided throughout this page. Feel free to copy 
     - IP or hostname of the Frigate NVR
 - **ignoressl** (Optional - Default: `false`)
     - Set to `true` to allow self-signed certificates
+- **headers** (Optional)
+    - Send additional HTTP headers to Frigate
+    - Useful for things like authentication
+    - Header format: `Header: Value`
+    - Example: `Authorization: Basic abcd1234`
 
 ```yaml title="Config File Snippet"
 frigate:
   server: nvr.your.domain.tld
   ignoressl: true
+  headers:
+    - Authorization: Basic abcd1234
 ```
 
 ### WebAPI
@@ -372,9 +379,7 @@ monitor:
   ignoressl: 
 ```
 
-
 ---
-
 
 ## Sample Config { data-search-exclude }
 
@@ -384,6 +389,7 @@ A full config file template has been provided below:
 frigate:
   server: 
   ignoressl: 
+  headers:
 
   webapi:
     enabled: 

--- a/docs/config.md
+++ b/docs/config.md
@@ -324,6 +324,31 @@ alerts:
     ttl:
 ```
 
+### Nfty
+
+!!!note
+    The default Frigate-Notify alert message uses Markdown. Currently, Nfty only supports Markdown in the web browser. This means that mobile notifications will be shown in plain-text & display un-rendered Markdown syntax. 
+
+- **enabled** (Optional - Default: `false`)
+    - Set to `true` to enable alerting via Nfty
+- **server** (Required)
+    - Full URL of the desired Nfty server
+    - Required if this alerting method is enabled
+- **topic** (Required)
+    - Destination topic that will receive alert notifications
+    - Required if this alerting method is enabled
+- **ignoressl** (Optional - Default: `false`)
+    - Set to `true` to allow self-signed certificates
+
+```yaml title="Config File Snippet"
+alerts: 
+  nfty:
+    enabled: true
+    server: https://nfty.your.domain.tld
+    topic: frigate
+    ignoressl: true
+```
+
 ## Monitor
 
 If enabled, this application will check in with tools like [HealthChecks](https://github.com/healthchecks/healthchecks) or [Uptime Kuma](https://github.com/louislam/uptime-kuma) on a regular interval for health / status monitoring.
@@ -430,6 +455,12 @@ alerts:
     retry:
     expire:
     ttl:
+
+  nfty:
+    enabled: false
+    server:
+    topic:
+    ignoressl:
 
 monitor:
   enabled: false

--- a/events/api.go
+++ b/events/api.go
@@ -35,9 +35,10 @@ func CheckForEvents() {
 	log.Println("Checking for new events...")
 
 	// Query events
-	response, err := util.HTTPGet(url, config.ConfigData.Frigate.Insecure)
+	response, err := util.HTTPGet(url, config.ConfigData.Frigate.Insecure, config.ConfigData.Frigate.Headers...)
 	if err != nil {
 		log.Printf("Cannot get events from %s", url)
+		log.Printf("Error received: %s", err)
 	}
 
 	var events []Event
@@ -87,7 +88,7 @@ func CheckForEvents() {
 
 // GetSnapshot downloads a snapshot from Frigate
 func GetSnapshot(snapshotURL, eventID string) io.Reader {
-	response, err := util.HTTPGet(snapshotURL, config.ConfigData.Frigate.Insecure)
+	response, err := util.HTTPGet(snapshotURL, config.ConfigData.Frigate.Insecure, config.ConfigData.Frigate.Headers...)
 	if err != nil {
 		log.Println("Could not access snaphot. Error: ", err)
 	}

--- a/example-config.yml
+++ b/example-config.yml
@@ -10,6 +10,11 @@ frigate:
   # Set to true if using SSL & a self-signed certificate
   ignoressl: false
 
+  # List of HTTP headers to send to Frigate, in format Header: Value
+  headers:
+    # Example:
+    # - Authorization: Basic abcd1234
+
   webapi:
     # Set to true to enable event collection via the web API
     enabled: 

--- a/example-config.yml
+++ b/example-config.yml
@@ -127,6 +127,16 @@ alerts:
     # Optional message lifetime
     ttl:
 
+  # Nfty Config
+  nfty:
+    # Set to true to enable alerting via
+    enabled: false
+    # URL of Nfty server
+    server:
+    # Nfty topic for notifications
+    topic:
+    # Set to true if using SSL & a self-signed certificate
+    ignoressl:
 
 ## App Monitoring
 # Sends HTTP GET to provided URL for aliveness checks

--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -29,4 +29,7 @@ func SendAlert(message, snapshotURL string, snapshot io.Reader, eventid string) 
 	if config.ConfigData.Alerts.Pushover.Enabled {
 		SendPushoverMessage(message, bytes.NewReader(snap), eventid)
 	}
+	if config.ConfigData.Alerts.Nfty.Enabled {
+		SendNftyPush(message, bytes.NewReader(snap), eventid)
+	}
 }

--- a/notifier/gotify.go
+++ b/notifier/gotify.go
@@ -49,13 +49,14 @@ func SendGotifyPush(message, snapshotURL string, eventid string) {
 
 	data, err := json.Marshal(payload)
 	if err != nil {
-		log.Println("Event ID %v - Unable to build Gotify payload: ", eventid, err)
+		log.Printf("Event ID %v - Unable to build Gotify payload: %v", eventid, err)
 		return
 	}
 
 	gotifyURL := fmt.Sprintf("%s/message?token=%s&", config.ConfigData.Alerts.Gotify.Server, config.ConfigData.Alerts.Gotify.Token)
 
-	response, err := util.HTTPPost(gotifyURL, config.ConfigData.Alerts.Gotify.Insecure, data)
+	header := map[string]string{"Content-Type": "application/json"}
+	response, err := util.HTTPPost(gotifyURL, config.ConfigData.Alerts.Gotify.Insecure, data, header)
 	if err != nil {
 		log.Print("Failed to send Gotify notification: ", err)
 		return

--- a/notifier/nfty.go
+++ b/notifier/nfty.go
@@ -1,0 +1,45 @@
+package notifier
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/0x2142/frigate-notify/config"
+	"github.com/0x2142/frigate-notify/util"
+)
+
+// SendNftyPush forwards alert messages to Nfty server
+func SendNftyPush(message string, snapshot io.Reader, eventid string) {
+	NftyURL := fmt.Sprintf("%s/%s", config.ConfigData.Alerts.Nfty.Server, config.ConfigData.Alerts.Nfty.Topic)
+
+	// Set headers
+	var headers []map[string]string
+	headers = append(headers, map[string]string{"Content-Type": "text/markdown"})
+	headers = append(headers, map[string]string{"X-Title": config.ConfigData.Alerts.General.Title})
+
+	// Set action link to the recorded clip
+	clip := fmt.Sprintf("%s/api/events/%s/clip.mp4", config.ConfigData.Frigate.Server, eventid)
+	headers = append(headers, map[string]string{"X-Actions": "view, View Clip, " + clip + ", clear=true"})
+
+	var attachment []byte
+	if snapshot != nil {
+		headers = append(headers, map[string]string{"X-Filename": "snapshot.jpg"})
+		attachment, _ = io.ReadAll(snapshot)
+	} else {
+		message += "\n\nNo snapshot saved."
+	}
+
+	// Escape newlines in message
+	message = strings.ReplaceAll(message, "\n", "\\n")
+	headers = append(headers, map[string]string{"X-Message": message})
+
+	_, err := util.HTTPPost(NftyURL, config.ConfigData.Alerts.Nfty.Insecure, attachment, headers...)
+	if err != nil {
+		log.Print("Failed to send Nfty notification: ", err)
+		return
+	}
+
+	log.Printf("Event ID %v - Nfty alert sent", eventid)
+}

--- a/util/httpclient.go
+++ b/util/httpclient.go
@@ -3,13 +3,15 @@ package util
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 )
 
 // HTTPGet is a simple HTTP client function to return page body
-func HTTPGet(url string, insecure bool) ([]byte, error) {
+func HTTPGet(url string, insecure bool, headers ...map[string]string) ([]byte, error) {
 
 	// New HTTP Client
 	client := http.Client{Timeout: 10 * time.Second}
@@ -25,6 +27,16 @@ func HTTPGet(url string, insecure bool) ([]byte, error) {
 		return nil, err
 	}
 
+	// Add headers
+	if len(headers) > 0 {
+		for _, h := range headers {
+			for k, v := range h {
+				req.Header.Add(k, v)
+			}
+
+		}
+	}
+
 	// Send HTTP GET
 	response, err := client.Do(req)
 	if err != nil {
@@ -36,6 +48,10 @@ func HTTPGet(url string, insecure bool) ([]byte, error) {
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if response.StatusCode != 200 {
+		return nil, errors.New(strconv.Itoa(response.StatusCode))
 	}
 
 	return body, nil
@@ -58,8 +74,8 @@ func HTTPPost(url string, insecure bool, payload []byte, headers ...map[string]s
 	if err != nil {
 		return nil, err
 	}
-	//req.Header.Set("Content-Type", "application/json")
 
+	// Add headers
 	if len(headers) > 0 {
 		for _, h := range headers {
 			for k, v := range h {
@@ -67,7 +83,6 @@ func HTTPPost(url string, insecure bool, payload []byte, headers ...map[string]s
 			}
 
 		}
-
 	}
 
 	// Send HTTP POST

--- a/util/httpclient.go
+++ b/util/httpclient.go
@@ -43,7 +43,7 @@ func HTTPGet(url string, insecure bool) ([]byte, error) {
 
 // HTTPPost performs an HTTP POST to the target URL
 // and includes auth parameters, ignoring certificates, etc
-func HTTPPost(url string, insecure bool, payload []byte) ([]byte, error) {
+func HTTPPost(url string, insecure bool, payload []byte, headers ...map[string]string) ([]byte, error) {
 	// New HTTP Client
 	client := http.Client{Timeout: 10 * time.Second}
 
@@ -58,7 +58,17 @@ func HTTPPost(url string, insecure bool, payload []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	//req.Header.Set("Content-Type", "application/json")
+
+	if len(headers) > 0 {
+		for _, h := range headers {
+			for k, v := range h {
+				req.Header.Add(k, v)
+			}
+
+		}
+
+	}
 
 	// Send HTTP POST
 	response, err := client.Do(req)


### PR DESCRIPTION
Add support for sending arbitrary HTTP headers to Frigate. This allows for ability to send authorization headers, or others if needed.

Original request #52 