### PR TITLE
Allow configuration from environment variables only

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git*
+docs
+screenshots
+example-config.yml
+docker-compose.yml
+mkdocs.yml
+README.md

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.3.0 
+        uses: sigstore/cosign-installer@v3.3.0
         with:
           cosign-release: 'v2.2.3'
 
@@ -42,13 +42,13 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/config/config.go
+++ b/config/config.go
@@ -149,7 +149,7 @@ type Ntfy struct {
 	Server   string              `fig:"server" default:""`
 	Topic    string              `fig:"topic" default:""`
 	Insecure bool                `fig:"ignoressl" default:false`
-	Headers  []map[string]string `fig:"headers"`
+	Headers  []map[string]string `fig:"headers" default:[]`
 	Template string              `fig:"template" default:""`
 }
 
@@ -238,7 +238,7 @@ func validateConfig() {
 		ConfigData.Frigate.StartupCheck.Interval = 30
 	}
 	for current_attempt < ConfigData.Frigate.StartupCheck.Attempts {
-		response, err = util.HTTPGet(statsAPI, ConfigData.Frigate.Insecure)
+		response, err = util.HTTPGet(statsAPI, ConfigData.Frigate.Insecure, ConfigData.Frigate.Headers...)
 		if err != nil {
 			log.Warn().
 				Err(err).


### PR DESCRIPTION
First of all, thank you so much for making this!

I'm introducing this change because I was getting the `Failed to load config file!` error on startup with a `docker-compose.yml` configured as such:
```yml
services:
  frigate:
    ...
  mqtt:
    ...
  frigate-notify:
    image: ghcr.io/0x2142/frigate-notify:v0.3.1
    depends_on: [mqtt, frigate]
    restart: unless-stopped
    environment:
      FN_FRIGATE_SERVER: http://frigate:5000
      FN_FRIGATE_MQTT_ENABLED: 'true'
      FN_FRIGATE_MQTT_SERVER: mqtt
      FN_FRIGATE_CAMERAS_EXCLUDE: '[some_room]'
      FN_ALERTS_PUSHOVER_ENABLED: 'true'
      FN_ALERTS_PUSHOVER_USERKEY: ${FN_ALERTS_PUSHOVER_USERKEY}
      FN_ALERTS_PUSHOVER_TOKEN: ${FN_ALERTS_PUSHOVER_TOKEN}
```

I'm not really in a position to store configs on the host machine so a volume-mounted config file was a no-go.

I've temporarily solved that problem by changing
`image: ghcr.io/0x2142/frigate-notify:v0.3.1`
to
`build: ./frigate-notify`
where the `frigate-notify` directory has the following `Dockerfile`:
```dockerfile
FROM alpine:latest as emptyconf

RUN echo "---" > /config.yml

FROM ghcr.io/0x2142/frigate-notify:v0.3.1

COPY --from=emptyconf /config.yml /app/config.yml
```

It all works perfectly like that, but it would be nice to not have to insert an empty config into a custom built container image so that I can use environment variables for all of the configuration I need.

This PR will warn if the specified/defaulted config file cannot be read, but will continue to try to load the config from the environment alone which would then error out [here](https://github.com/kkyr/fig/blob/master/fig.go#L292) if `FN_FRIGATE_SERVER` was not specified.

I've also got a commit in here that sends the configured headers along with the connectivity test since the docs give a basic auth example.