### PR TITLE
Add ability to include env vars in templates

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
  - Ability to [modify snapshot](https://frigate-notify.0x2142.com/latest/config/file/#general) when retrieved from Frigate: include bounding box / timestamp or crop snapshot
  - Allow use of [template variables](https://frigate-notify.0x2142.com/latest/config/templates/#available-variables) within HTTP headers sent to notification providers
      - Ntfy action button can now be overrriden by defining a custom `X-Actions` header in the config file
+     - Templates can also now include information from [environment variables](https://frigate-notify.0x2142.com/latest/config/templates/#environment-variables)
 
 ## [v0.3.2](https://github.com/0x2142/frigate-notify/releases/tag/v0.3.2) - Jun 13 2024
 

--- a/docs/config/templates.md
+++ b/docs/config/templates.md
@@ -63,3 +63,16 @@ The list below doesn't contain every possible variable, just a few of the most c
 | .Extra.ZoneList        | List of current zones object is in                                                                                       |
 | .Extra.LocalURL        | Frigate server URL as specified under `frigate > server`                                                                 |
 | .Extra.PublicURL       | Frigate Public URL as specified under `frigate > public_url`                                                             |
+
+### Environment variables
+
+Templates can also retrieve values from environment variables using a built-in `env` function. Environment variables used within templates must contain the `FN_` prefix.
+
+For example, storing an authentication token within an env variable:
+
+```yaml
+...
+  headers:
+    - Authorization: Basic {{ env "FN_AUTH_BASIC" }}
+...
+```


### PR DESCRIPTION
Environment variables can now be retrieved using `env`, for example: `{{ env  "FN_SOME_ENV }}`

Accessed variables must be prefixed with `FN_` 