### PR TITLE
Fix gotify snap url

### DIFF
--- a/events/api.go
+++ b/events/api.go
@@ -85,7 +85,7 @@ func CheckForEvents() {
 		}
 
 		// Send alert with snapshot
-		notifier.SendAlert(event, snapshotURL, snapshot, event.ID)
+		notifier.SendAlert(event, snapshot, event.ID)
 	}
 
 }

--- a/events/mqtt.go
+++ b/events/mqtt.go
@@ -124,7 +124,7 @@ func processEvent(client mqtt.Client, msg mqtt.Message) {
 		}
 
 		// Send alert with snapshot
-		notifier.SendAlert(event.After.Event, snapshotURL, snapshot, event.After.ID)
+		notifier.SendAlert(event.After.Event, snapshot, event.After.ID)
 	}
 
 	// Clear event cache entry when event ends

--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -19,7 +19,7 @@ import (
 var TemplateFiles embed.FS
 
 // SendAlert forwards alert information to all enabled alerting methods
-func SendAlert(event models.Event, snapshotURL string, snapshot io.Reader, eventid string) {
+func SendAlert(event models.Event, snapshot io.Reader, eventid string) {
 	// Add Frigate Major version metadata
 	event.Extra.FrigateMajorVersion = config.ConfigData.Frigate.Version
 	// Create copy of snapshot for each alerting method
@@ -31,7 +31,7 @@ func SendAlert(event models.Event, snapshotURL string, snapshot io.Reader, event
 		go SendDiscordMessage(event, bytes.NewReader(snap))
 	}
 	if config.ConfigData.Alerts.Gotify.Enabled {
-		go SendGotifyPush(event, snapshotURL)
+		go SendGotifyPush(event)
 	}
 	if config.ConfigData.Alerts.SMTP.Enabled {
 		go SendSMTP(event, bytes.NewReader(snap))

--- a/notifier/gotify.go
+++ b/notifier/gotify.go
@@ -34,8 +34,17 @@ type gotifyPayload struct {
 	} `json:"extras,omitempty"`
 }
 
+const eventsURI = "/api/events"
+const snapshotURI = "/snapshot.jpg"
+
 // SendGotifyPush forwards alert messages to Gotify push notification server
-func SendGotifyPush(event models.Event, snapshotURL string) {
+func SendGotifyPush(event models.Event) {
+	var snapshotURL string
+	if config.ConfigData.Frigate.PublicURL != "" {
+		snapshotURL = config.ConfigData.Frigate.PublicURL + eventsURI + "/" + event.ID + snapshotURI
+	} else {
+		snapshotURL = config.ConfigData.Frigate.Server + eventsURI + "/" + event.ID + snapshotURI
+	}
 	// Build notification
 	var message string
 	if config.ConfigData.Alerts.Gotify.Template != "" {


### PR DESCRIPTION
Update Gotify to use `public_url` for the snapshot image, when it is configured. Most other alert profiles are already using this as defined in the message templates, but other methods are able to directly upload snapshot image. Gotify requires attaching the snapshot by providing a direct link which is being manually appended to the message, so this got missed. Fixed now though!

(#142)