### PR TITLE
Fix issue with alerts for multi-event review items

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.23-alpine AS build
 
 WORKDIR /app
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 Matt Schmitz
+Copyright (c) 2023-2025 Matt Schmitz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/api/v1/notiftest.go
+++ b/api/v1/notiftest.go
@@ -45,7 +45,7 @@ func PostNotifTest(ctx context.Context, input *struct{}) (*NotifTestOutput, erro
 		json.Unmarshal([]byte(response), &events)
 
 		// Send test notification
-		notifier.SendAlert(events[0])
+		notifier.SendAlert(events)
 	}()
 
 	log.Trace().

--- a/config/internal.go
+++ b/config/internal.go
@@ -6,7 +6,7 @@ var Internal models.InternalConfig
 
 func init() {
 	Internal.Status.Notifications.Enabled = true
-	Internal.AppVersion = "v0.4.0"
+	Internal.AppVersion = "v0.4.1-dev"
 	Internal.Status.Health = "n/a"
 	Internal.Status.API = "n/a"
 	Internal.Status.Frigate.API = "n/a"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.4.1](https://github.com/0x2142/frigate-notify/releases/tag/v0.4.1) - In Development
+ - Fix issue with alert-level filters where notification would not be sent if first detected label was filtered
+
 ## [v0.4.0](https://github.com/0x2142/frigate-notify/releases/tag/v0.4.0) - Jan 27 2025
  - Support for notification based on Alerts & Detections via Frigate Reviews
      - ⚠️ **Note:** Reviews mode is now the default with this release

--- a/events/events.go
+++ b/events/events.go
@@ -43,7 +43,7 @@ func processEvent(event models.Event) {
 	}
 
 	// Send alert with snapshot
-	notifier.SendAlert(event)
+	notifier.SendAlert([]models.Event{event})
 }
 
 func recheckEvent(event models.Event) models.Event {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/0x2142/frigate-notify
 
-go 1.22
+go 1.23
 
-toolchain go1.22.1
+toolchain go1.23.5
 
 require (
 	github.com/danielgtaylor/huma/v2 v2.27.0

--- a/models/event.go
+++ b/models/event.go
@@ -48,6 +48,7 @@ type Event struct {
 type ExtraFields struct {
 	FormattedTime       string
 	TopScorePercent     string
+	LabelList           string
 	ZoneList            string
 	LocalURL            string
 	PublicURL           string

--- a/notifier/filters.go
+++ b/notifier/filters.go
@@ -8,12 +8,37 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var (
+	cameras   []string
+	labels    []string
+	sublabels []string
+	zones     []string
+)
+
 // checkAlertFilters will determine which notification provider is able to send this alert
-func checkAlertFilters(event models.Event, filters models.AlertFilter, provider notifMeta) bool {
+func checkAlertFilters(events []models.Event, filters models.AlertFilter, provider notifMeta) bool {
 	log.Trace().
 		Str("provider", provider.name).
 		Int("provider_id", provider.index).
 		Msg("Checking alert filters")
+
+	// Collect event details
+	for _, event := range events {
+		if !slices.Contains(cameras, event.Camera) {
+			cameras = append(cameras, event.Camera)
+		}
+		if !slices.Contains(labels, event.Label) {
+			labels = append(labels, event.Label)
+		}
+		if !slices.Contains(sublabels, event.SubLabel) {
+			sublabels = append(sublabels, event.SubLabel)
+		}
+		for _, zone := range event.CurrentZones {
+			if !slices.Contains(zones, zone) {
+				zones = append(zones, zone)
+			}
+		}
+	}
 
 	// Check against quiet hours
 	currentTime, _ := time.Parse("15:04:05", time.Now().Format("15:04:05"))
@@ -49,11 +74,18 @@ func checkAlertFilters(event models.Event, filters models.AlertFilter, provider 
 	log.Trace().
 		Str("provider", provider.name).
 		Int("provider_id", provider.index).
-		Str("camera", event.Camera).
+		Strs("cameras", cameras).
 		Strs("allowed", filters.Cameras).
 		Msg("Check allowed cameras")
 	if len(filters.Cameras) >= 1 {
-		if !slices.Contains(filters.Cameras, event.Camera) {
+		match := false
+		for _, camera := range cameras {
+			if slices.Contains(filters.Cameras, camera) {
+				match = true
+				break
+			}
+		}
+		if !match {
 			log.Debug().
 				Str("provider", provider.name).
 				Int("provider_id", provider.index).
@@ -66,17 +98,18 @@ func checkAlertFilters(event models.Event, filters models.AlertFilter, provider 
 	log.Trace().
 		Str("provider", provider.name).
 		Int("provider_id", provider.index).
-		Strs("zones", event.CurrentZones).
+		Strs("zones", zones).
 		Strs("allowed", filters.Zones).
 		Msg("Check allowed zone")
 	if len(filters.Zones) >= 1 {
-		matchzone := false
-		for _, zone := range event.CurrentZones {
+		match := false
+		for _, zone := range zones {
 			if slices.Contains(filters.Zones, zone) {
-				matchzone = true
+				match = true
+				break
 			}
 		}
-		if !matchzone {
+		if !match {
 			log.Debug().
 				Str("provider", provider.name).
 				Int("provider_id", provider.index).
@@ -89,11 +122,18 @@ func checkAlertFilters(event models.Event, filters models.AlertFilter, provider 
 	log.Trace().
 		Str("provider", provider.name).
 		Int("provider_id", provider.index).
-		Str("label", event.Label).
+		Strs("labels", labels).
 		Strs("allowed", filters.Labels).
 		Msg("Check allowed label")
 	if len(filters.Labels) >= 1 {
-		if !slices.Contains(filters.Labels, event.Label) {
+		match := false
+		for _, label := range labels {
+			if !slices.Contains(filters.Labels, label) {
+				match = true
+				break
+			}
+		}
+		if !match {
 			log.Debug().
 				Str("provider", provider.name).
 				Int("provider_id", provider.index).
@@ -106,15 +146,18 @@ func checkAlertFilters(event models.Event, filters models.AlertFilter, provider 
 	log.Trace().
 		Str("provider", provider.name).
 		Int("provider_id", provider.index).
-		Str("sublabel", event.SubLabel).
+		Strs("sublabels", sublabels).
 		Strs("allowed", filters.Sublabels).
 		Msg("Check allowed sublabel")
 	if len(filters.Sublabels) >= 1 {
-		matchsublabel := false
-		if slices.Contains(filters.Sublabels, event.SubLabel) {
-			matchsublabel = true
+		match := false
+		for _, sublabel := range sublabels {
+			if slices.Contains(filters.Sublabels, sublabel) {
+				match = true
+				break
+			}
 		}
-		if !matchsublabel {
+		if !match {
 			log.Debug().
 				Str("provider", provider.name).
 				Int("provider_id", provider.index).

--- a/templates/html.template
+++ b/templates/html.template
@@ -1,8 +1,8 @@
 Detection at {{ .Extra.FormattedTime }} <br />
 Camera: {{ .Extra.CameraName }} <br />
-{{ if ne .Label "" }}Label: {{ .Label }} ({{ .Extra.TopScorePercent }}) <br /> {{ end }}
-{{ if ge (len .Extra.Audio ) 1 }}Audio: {{ .Extra.Audio }}<br /> {{ end }}
-{{ if ge (len .Zones ) 1 }}Zone(s): {{ .Extra.ZoneList }}
+{{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }} <br /> {{ end }}
+{{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }}<br /> {{ end }}
+{{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
 {{ end }}
 <br />
 Links: <a href="{{if ge .Extra.FrigateMajorVersion 14 }}{{ .Extra.PublicURL }}/#{{ .Camera }}{{ else }}{{ .Extra.PublicURL }}/cameras/{{ .Camera }}{{ end }}">Camera</a>{{ if ne .Extra.ReviewLink "" }} | <a href="{{ .Extra.ReviewLink }}">Review Event</a>{{ else }}{{ if .HasClip }} | <a href="{{ .Extra.EventLink }}">Event Clip</a> <br />{{ end }}{{ end }}

--- a/templates/markdown.template
+++ b/templates/markdown.template
@@ -1,8 +1,8 @@
 Detection at {{ .Extra.FormattedTime }}  
 Camera: {{ .Extra.CameraName }}  
-{{ if ne .Label "" }}Label: {{ .Label }} ({{ .Extra.TopScorePercent }}) {{ end }}
-{{ if ge (len .Extra.Audio ) 1 }}Audio: {{ .Extra.Audio }} {{ end }}
-{{ if ge (len .Zones ) 1 }}Zone(s): {{ .Extra.ZoneList }}  
+{{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }} {{ end }}
+{{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }} {{ end }}
+{{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
 {{ end }}
 Links: [Camera]({{if ge .Extra.FrigateMajorVersion 14 }}{{ .Extra.PublicURL }}/#{{ .Camera }}{{ else }}{{ .Extra.PublicURL }}/cameras/{{ .Camera }}{{ end }}){{if ne .Extra.ReviewLink "" }} | [Review Event]({{ .Extra.ReviewLink }}){{else}}{{ if .HasClip }} | [Event Clip]({{ .Extra.EventLink }}){{ end }}{{ end }}
 

--- a/templates/plaintext.template
+++ b/templates/plaintext.template
@@ -1,8 +1,8 @@
 Detection at {{ .Extra.FormattedTime }}
 Camera: {{ .Extra.CameraName }}
-{{ if ne .Label "" }}Label: {{ .Label }} ({{ .Extra.TopScorePercent }}) {{ end }}
-{{ if ge (len .Extra.Audio ) 1 }}Audio: {{ .Extra.Audio }} {{ end }}
-{{ if ge (len .Zones ) 1 }}Zone(s): {{ .Extra.ZoneList }}
+{{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }} {{ end }}
+{{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }} {{ end }}
+{{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
 {{ end }}
 Links:
 {{if ge .Extra.FrigateMajorVersion 14 }} - Camera: {{ .Extra.PublicURL }}/#{{ .Camera }}{{else}} - Camera: {{ .Extra.PublicURL }}/cameras/{{ .Camera }}{{end}}


### PR DESCRIPTION
Early support for /reviews included using only the first detection as a basis for notifications, but all events in a review would pass through global filters. With addition of alert-level filtering, this meant that only the first detection would make it to the notifications - so a review item with multiple events might be not notify, if the qualifying event was not the first in the review