### PR TITLE
Swap telegram sdk

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.4.4](https://github.com/0x2142/frigate-notify/releases/tag/v0.4.4) - TBD
+ - Add support for `message_thread_id` to [Telegram](https://frigate-notify.0x2142.com/latest/config/file/#telegram) notifications
+ - Fix issue with Webhook default message template
+
 ## [v0.4.3](https://github.com/0x2142/frigate-notify/releases/tag/v0.4.3) - Feb 21 2025
  - Add support for notifications via [Apprise API](https://frigate-notify.0x2142.com/latest/config/file/#apprise-api)
  - Add retry interval for collecting snapshots from Frigate

--- a/docs/config/file.md
+++ b/docs/config/file.md
@@ -638,6 +638,8 @@ Within the response, locate your message to the bot, then grab the ID under `mes
 - **token** (Required)
     - Bot token generated from [@BotFather](https://core.telegram.org/bots#how-do-i-create-a-bot)
     - Required if this alerting method is enabled
+- **message_thread_id** (Optional)
+    - Optionally send notification to a message thread by ID
 - **template** (Optional)
     - Optionally specify a custom notification template
     - For more information on template syntax, see [Alert Templates](./templates.md#alert-templates)
@@ -647,6 +649,7 @@ alerts:
   telegram:
     enabled: true
     chatid: 123456789
+    message_thread_id: 100
     token: 987654321:ABCDEFGHIJKLMNOP
     template:
 ```

--- a/docs/config/sample.md
+++ b/docs/config/sample.md
@@ -137,6 +137,7 @@ alerts:
   telegram:
     enabled: false
     chatid:
+    message_thread_id:
     token:
     template:
 

--- a/example-config.yml
+++ b/example-config.yml
@@ -284,6 +284,8 @@ alerts:
     enabled: false
     # Chat ID of alert recipient
     chatid:
+    # Message Thead ID
+    message_thread_id:
     # Bot API token
     token:
     # Custom notification template, if desired

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.23
 toolchain go1.23.5
 
 require (
+	github.com/OvyFlash/telegram-bot-api v0.0.0-20241219171906-3f2ca0c14ada
 	github.com/danielgtaylor/huma/v2 v2.27.0
 	github.com/disgoorg/disgo v0.18.14
 	github.com/disgoorg/json v1.2.0
 	github.com/eclipse/paho.mqtt.golang v1.5.0
-	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/gregdel/pushover v1.3.1
 	github.com/kkyr/fig v0.4.0
 	github.com/maypok86/otter v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/OvyFlash/telegram-bot-api v0.0.0-20241219171906-3f2ca0c14ada h1:5ZtieioZyyfiJsGvjpj3d5Eso/3YjJJhNQ1M8at5U5k=
+github.com/OvyFlash/telegram-bot-api v0.0.0-20241219171906-3f2ca0c14ada/go.mod h1:2nRUdsKyWhvezqW/rBGWEQdcTQeTtnbSNd2dgx76WYA=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danielgtaylor/huma/v2 v2.27.0 h1:yxgJ8GqYqKeXw/EnQ4ZNc2NBpmn49AlhxL2+ksSXjUI=
@@ -16,8 +18,6 @@ github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjO
 github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
 github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
 github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/models/config.go
+++ b/models/config.go
@@ -191,11 +191,12 @@ type SMTP struct {
 }
 
 type Telegram struct {
-	Enabled  bool        `fig:"enabled" json:"enabled" enum:"true,false" doc:"Enable notifications via Telegram" default:false`
-	ChatID   int64       `fig:"chatid" json:"chatid,omitempty" minimum:"1" doc:"Telegram chat ID" default:"0"`
-	Token    string      `fig:"token" json:"token,omitempty" doc:"Telegram bot token" default:""`
-	Template string      `fig:"template" json:"template,omitempty" doc:"Custom message template" default:""`
-	Filters  AlertFilter `fig:"filters" json:"filters,omitempty" doc:"Filter notifications sent via this provider"`
+	Enabled         bool        `fig:"enabled" json:"enabled" enum:"true,false" doc:"Enable notifications via Telegram" default:false`
+	ChatID          int64       `fig:"chatid" json:"chatid,omitempty" minimum:"1" doc:"Telegram chat ID" default:"0"`
+	MessageThreadID int         `fig:"message_thread_id" json:"message_thread_id,omitempty" doc:"Send message to thread by ID" default:"0`
+	Token           string      `fig:"token" json:"token,omitempty" doc:"Telegram bot token" default:""`
+	Template        string      `fig:"template" json:"template,omitempty" doc:"Custom message template" default:""`
+	Filters         AlertFilter `fig:"filters" json:"filters,omitempty" doc:"Filter notifications sent via this provider"`
 }
 
 type Webhook struct {

--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -41,6 +41,9 @@ func SendTelegramMessage(event models.Event, snapshot io.Reader, provider notifM
 	if event.HasSnapshot {
 		// Attach & send snapshot
 		photo := tgbotapi.NewPhoto(profile.ChatID, tgbotapi.FileReader{Name: "Snapshot", Reader: snapshot})
+		if profile.MessageThreadID != 0 {
+			photo.MessageThreadID = profile.MessageThreadID
+		}
 		photo.Caption = message
 		photo.ParseMode = "HTML"
 		response, err := bot.Send(photo)
@@ -61,6 +64,9 @@ func SendTelegramMessage(event models.Event, snapshot io.Reader, provider notifM
 	} else {
 		// Send plain text message if no snapshot available
 		msg := tgbotapi.NewMessage(profile.ChatID, message)
+		if profile.MessageThreadID != 0 {
+			msg.MessageThreadID = profile.MessageThreadID
+		}
 		msg.ParseMode = "HTML"
 		response, err := bot.Send(msg)
 		log.Trace().

--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/0x2142/frigate-notify/config"
 	"github.com/0x2142/frigate-notify/models"
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	tgbotapi "github.com/OvyFlash/telegram-bot-api"
 )
 
 // SendTelegramMessage sends alert through Telegram to individual users


### PR DESCRIPTION
Old Telegram SDK not maintained any longer, swapping to better fork. Added support for `message_thread_id` in Telegram notifs