### PR TITLE
Support for license plate recognition

### DIFF
--- a/api/v1/notiftest.go
+++ b/api/v1/notiftest.go
@@ -41,6 +41,7 @@ func PostNotifTest(ctx context.Context, input *struct{}) (*NotifTestOutput, erro
 			log.Error().
 				Err(err).
 				Msgf("Cannot get event from %s", url)
+			return
 		}
 		json.Unmarshal([]byte(response), &events)
 

--- a/config/validate.go
+++ b/config/validate.go
@@ -411,6 +411,9 @@ func (c *Config) validateAlertGeneral() []string {
 	// Notify_Detections
 	log.Debug().Msgf("Notify on Detections: %v", c.Alerts.General.NotifyDetections)
 
+	// Wait for license plates
+	log.Debug().Msgf("Wait for license plate recognition: %v", c.Alerts.General.WaitforLPR)
+
 	// Check title template syntax
 	if msg := validateTemplate("Alert Title", c.Alerts.General.Title); msg != "" {
 		alertErrors = append(alertErrors, msg)

--- a/config/validate.go
+++ b/config/validate.go
@@ -411,9 +411,6 @@ func (c *Config) validateAlertGeneral() []string {
 	// Notify_Detections
 	log.Debug().Msgf("Notify on Detections: %v", c.Alerts.General.NotifyDetections)
 
-	// Wait for license plates
-	log.Debug().Msgf("Wait for license plate recognition: %v", c.Alerts.General.WaitforLPR)
-
 	// Check title template syntax
 	if msg := validateTemplate("Alert Title", c.Alerts.General.Title); msg != "" {
 		alertErrors = append(alertErrors, msg)
@@ -496,6 +493,26 @@ func (c *Config) validateLabelFiltering() []string {
 	} else {
 		log.Debug().Msg("No Sublabels excluded")
 	}
+
+	// Check license plate filtering config
+	log.Debug().Msgf("Wait for license plate recognition: %v", c.Alerts.LicensePlate.Enabled)
+	if len(c.Alerts.LicensePlate.Allow) > 0 {
+		log.Debug().Msg("license plates to generate alerts for:")
+		for _, c := range c.Alerts.LicensePlate.Allow {
+			log.Debug().Msgf(" - %v", c)
+		}
+	} else {
+		log.Debug().Msg("All license plates included in alerts")
+	}
+	if len(c.Alerts.LicensePlate.Block) > 0 {
+		log.Debug().Msg("License plates to exclude from alerting:")
+		for _, c := range c.Alerts.LicensePlate.Block {
+			log.Debug().Msgf(" - %v", c)
+		}
+	} else {
+		log.Debug().Msg("No license plates excluded")
+	}
+
 	return labelErrors
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,8 @@
  - Add support for `message_thread_id` to [Telegram](https://frigate-notify.0x2142.com/latest/config/file/#telegram) notifications
  - Add review/event link for Pushover action button
  - Add ability to disable Discord notifications being sent as embedded message
- - Add ability to wait for [license plate recognition](https://frigate-notify.0x2142.com/latest/config/file/#general) data from Frigate to be included in notifications
+ - Add ability to wait for [license plate recognition](https://frigate-notify.0x2142.com/latest/config/file/#license-plate) data from Frigate to be included in notifications
+ - Add ability to allow / block license plates from generating notification
  - Fix issue with Webhook default message template
 
 ## [v0.4.3](https://github.com/0x2142/frigate-notify/releases/tag/v0.4.3) - Feb 21 2025

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
  - Add support for `message_thread_id` to [Telegram](https://frigate-notify.0x2142.com/latest/config/file/#telegram) notifications
  - Add review/event link for Pushover action button
  - Add ability to disable Discord notifications being sent as embedded message
+ - Add ability to wait for [license plate recognition](https://frigate-notify.0x2142.com/latest/config/file/#general) data from Frigate to be included in notifications
  - Fix issue with Webhook default message template
 
 ## [v0.4.3](https://github.com/0x2142/frigate-notify/releases/tag/v0.4.3) - Feb 21 2025

--- a/docs/config/file.md
+++ b/docs/config/file.md
@@ -186,6 +186,9 @@ All alert providers (Discord, Gotify, etc) also support optional filters & the a
     - Specify what to do with events that only contain audio detection
     - By default, these events will generate notifications
     - Set to `drop` to silently drop these events & not send notifications
+- **wait_for_lpr** (Optional - Default: `false`)
+    - Specify whether to wait for license plate recognition data when cars & license plates are detected
+    - This will re-check the Frigate for license plate information every 2 seconds with a 10 second maximum
 
 ```yaml title="Config File Snippet"
 alerts:
@@ -200,6 +203,7 @@ alerts:
     notify_once:
     notify_detections:
     audio_only:
+    wait_for_lpr:
 ```
 
 ### Quiet Hours

--- a/docs/config/file.md
+++ b/docs/config/file.md
@@ -186,9 +186,6 @@ All alert providers (Discord, Gotify, etc) also support optional filters & the a
     - Specify what to do with events that only contain audio detection
     - By default, these events will generate notifications
     - Set to `drop` to silently drop these events & not send notifications
-- **wait_for_lpr** (Optional - Default: `false`)
-    - Specify whether to wait for license plate recognition data when cars & license plates are detected
-    - This will re-check the Frigate for license plate information every 2 seconds with a 10 second maximum
 
 ```yaml title="Config File Snippet"
 alerts:
@@ -203,7 +200,6 @@ alerts:
     notify_once:
     notify_detections:
     audio_only:
-    wait_for_lpr:
 ```
 
 ### Quiet Hours
@@ -303,6 +299,32 @@ Filter by sublabels, just like normal [labels](#labels).
 ```yaml title="Config File Snippet"
 alerts:
   sublabels:
+    allow:
+     - ABCD
+     - EFGH
+    block:
+     - XYZ
+```
+
+### License Plate
+
+Include license plate recognition data in notifications, if enabled in Frigate.
+
+- **enabled** (Optional - Default: `false`)
+    - Specify whether to wait for license plate recognition data when cars & license plates are detected
+    - This will re-check the Frigate for license plate information every 2 seconds with a 10 second maximum
+- **allow** (Optional)
+    - Specify a list of license plates to allow notifications
+    - If set, all other license plates will be ignored
+    - If not set, all license plates will generate notifications
+- **block** (Optional)
+    - Specify a list of license plates to always ignore
+    - This takes precedence over the `allow` list
+
+```yaml title="Config File Snippet"
+alerts:
+  license_plate:
+    enabled: true
     allow:
      - ABCD
      - EFGH

--- a/docs/config/sample.md
+++ b/docs/config/sample.md
@@ -48,6 +48,7 @@ alerts:
     notify_detections:
     recheck_delay:
     audio_only:
+    wait_for_lpr:
 
   quiet:
     start:

--- a/docs/config/sample.md
+++ b/docs/config/sample.md
@@ -48,7 +48,6 @@ alerts:
     notify_detections:
     recheck_delay:
     audio_only:
-    wait_for_lpr:
 
   quiet:
     start:
@@ -74,6 +73,20 @@ alerts:
      - ABCD
     block:
      - EFGH
+
+  license_plate:
+    enabled: false
+    allow:
+    block:
+
+  apprise-api:
+    enabled: false
+    server:
+    token:
+    urls:
+    tags:
+    ignoressl:
+    template:
 
   discord:
     enabled: false

--- a/events/events.go
+++ b/events/events.go
@@ -38,7 +38,7 @@ func processEvent(event models.Event) {
 		Msgf("Event start time: %s", eventTime)
 
 	// Wait for license plate data before notifying, if set
-	if config.ConfigData.Alerts.General.WaitforLPR {
+	if config.ConfigData.Alerts.LicensePlate.Enabled {
 		waitforLPR(&event)
 	}
 

--- a/events/events.go
+++ b/events/events.go
@@ -37,6 +37,11 @@ func processEvent(event models.Event) {
 		Str("event_id", event.ID).
 		Msgf("Event start time: %s", eventTime)
 
+	// Wait for license plate data before notifying, if set
+	if config.ConfigData.Alerts.General.WaitforLPR {
+		waitforLPR(&event)
+	}
+
 	// Check that event passes configured filters
 	if !checkEventFilters(event) {
 		return
@@ -66,6 +71,7 @@ func recheckEvent(event models.Event) models.Event {
 		log.Error().
 			Err(err).
 			Msgf("Cannot get event from %s", url)
+		return event
 	}
 	config.Internal.Status.Health = "ok"
 	config.Internal.Status.Frigate.API = "ok"

--- a/events/filters.go
+++ b/events/filters.go
@@ -116,6 +116,11 @@ func checkEventFilters(event models.Event) bool {
 
 	}
 
+	// Check license plate filterd
+	if !isAllowedLabel(event.ID, event.Data.RecognizedLicensePlate, "license_plate") {
+		return false
+	}
+
 	// Default
 	return true
 }
@@ -190,7 +195,7 @@ func isAllowedZone(id string, zones []string) bool {
 	return false
 }
 
-// isAllowedLabel verifies whether a label or sublabel should be allowed to generate a notification
+// isAllowedLabel verifies whether a label, sublabel, or license plate should be allowed to generate a notification
 func isAllowedLabel(id string, label string, kind string) bool {
 	var blocked []string
 	var allowed []string
@@ -214,6 +219,17 @@ func isAllowedLabel(id string, label string, kind string) bool {
 			Strs("allowed", allowed).
 			Msg("Check allowed sublabel")
 	}
+	if kind == "license_plate" {
+		blocked = config.ConfigData.Alerts.LicensePlate.Block
+		allowed = config.ConfigData.Alerts.LicensePlate.Allow
+		log.Trace().
+			Str("event_id", id).
+			Str("license_plate", label).
+			Strs("blocked", blocked).
+			Strs("allowed", allowed).
+			Msg("Check allowed license_plate")
+	}
+
 	// Check block list
 	if slices.Contains(blocked, label) {
 		log.Info().

--- a/events/reviews.go
+++ b/events/reviews.go
@@ -96,6 +96,11 @@ func processReview(review models.Review) {
 			break
 		}
 
+		// Wait for license plate data before notifying, if set
+		if config.ConfigData.Alerts.General.WaitforLPR {
+			waitforLPR(&detection)
+		}
+
 		// Add special link to review page
 		detection.Extra.ReviewLink = config.ConfigData.Frigate.PublicURL + "/review?id=" + review.ID
 
@@ -142,6 +147,7 @@ func recheckReview(review models.Review) models.Review {
 		log.Error().
 			Err(err).
 			Msgf("Cannot get event from %s", url)
+		return review
 	}
 	config.Internal.Status.Health = "ok"
 	config.Internal.Status.Frigate.API = "ok"

--- a/events/reviews.go
+++ b/events/reviews.go
@@ -89,16 +89,16 @@ func processReview(review models.Review) {
 			detection.TopScore = detection.Data.TopScore
 		}
 
+		// Wait for license plate data before notifying, if set
+		if config.ConfigData.Alerts.LicensePlate.Enabled {
+			waitforLPR(&detection)
+		}
+
 		// Check that event passes configured filters
 		detection.CurrentZones = detection.Zones
 		if !checkEventFilters(detection) {
 			reviewFiltered = true
 			break
-		}
-
-		// Wait for license plate data before notifying, if set
-		if config.ConfigData.Alerts.General.WaitforLPR {
-			waitforLPR(&detection)
 		}
 
 		// Add special link to review page

--- a/example-config.yml
+++ b/example-config.yml
@@ -102,6 +102,9 @@ alerts:
     # Allow audio-only events (no object detection)
     # Set to `drop` to disallow this
     audio_only: allow
+    # Wait for license plate recognition when car & license plate are detected
+    # By default, this is disabled. Re-checks Frigate up to 10 seconds after event is received for license plate data
+    wait_for_lpr:
 
 
   # If configured, ignore events between times below

--- a/example-config.yml
+++ b/example-config.yml
@@ -102,10 +102,6 @@ alerts:
     # Allow audio-only events (no object detection)
     # Set to `drop` to disallow this
     audio_only: allow
-    # Wait for license plate recognition when car & license plate are detected
-    # By default, this is disabled. Re-checks Frigate up to 10 seconds after event is received for license plate data
-    wait_for_lpr:
-
 
   # If configured, ignore events between times below
   quiet:
@@ -137,6 +133,15 @@ alerts:
     # Filter notifications to only specific sublabels allowed here
     allow:
     # List of sublabels to never generate notifications
+    block:
+
+  license_plate:
+    # Set to `true` to wait for license plate recognition when car & license plate are detected
+    # By default, this is disabled. Re-checks Frigate up to 10 seconds after event is received for license plate data
+    enabled:
+    # Filter notifications to only specific license plates allowed here
+    allow:
+    # List of license plates to never generate notifications
     block:
 
   apprise-api:

--- a/models/config.go
+++ b/models/config.go
@@ -47,22 +47,23 @@ type Cameras struct {
 }
 
 type Alerts struct {
-	General    General      `fig:"general" json:"general,omitempty" doc:"Common alert settings"`
-	Quiet      Quiet        `fig:"quiet" json:"quiet,omitempty" doc:"Alert quiet periods"`
-	Zones      Zones        `fig:"zones" json:"zones,omitempty" doc:"Allow/Block zones from alerting"`
-	Labels     Labels       `fig:"labels" json:"labels,omitempty" doc:"Allow/Block labels from alerting"`
-	SubLabels  Labels       `fig:"sublabels" json:"sublabels,omitempty" doc:"Allow/Block sublabels from alerting"`
-	AppriseAPI []AppriseAPI `fig:"apprise-api" json:"apprise-api,omitempty" doc:"Apprise API notification settings"`
-	Discord    []Discord    `fig:"discord" json:"discord,omitempty" doc:"Discord notification settings"`
-	Gotify     []Gotify     `fig:"gotify" json:"gotify,omitempty" doc:"Gotify notification settings"`
-	Matrix     []Matrix     `fig:"matrix" json:"matrix,omitempty" doc:"Matrix notification settings"`
-	Mattermost []Mattermost `fig:"mattermost" json:"mattermost,omitempty" doc:"Mattermost notification settings"`
-	Ntfy       []Ntfy       `fig:"ntfy" json:"ntfy,omitempty" doc:"Ntfy notification settings"`
-	Pushover   []Pushover   `fig:"pushover" json:"pushover,omitempty" doc:"Pushover notification settings"`
-	Signal     []Signal     `fig:"signal" json:"signal,omitempty" doc:"Signal notification settings"`
-	SMTP       []SMTP       `fig:"smtp" json:"smtp,omitempty" doc:"SMTP notification settings"`
-	Telegram   []Telegram   `fig:"telegram" json:"telegram,omitempty" doc:"Telegram notification settings"`
-	Webhook    []Webhook    `fig:"webhook" json:"webhook,omitempty" doc:"Webhook notification settings"`
+	General      General      `fig:"general" json:"general,omitempty" doc:"Common alert settings"`
+	Quiet        Quiet        `fig:"quiet" json:"quiet,omitempty" doc:"Alert quiet periods"`
+	Zones        Zones        `fig:"zones" json:"zones,omitempty" doc:"Allow/Block zones from alerting"`
+	Labels       Labels       `fig:"labels" json:"labels,omitempty" doc:"Allow/Block labels from alerting"`
+	SubLabels    Labels       `fig:"sublabels" json:"sublabels,omitempty" doc:"Allow/Block sublabels from alerting"`
+	LicensePlate LicensePlate `fig:"license_plate" json:"license_plate,omitempty" doc:"License plate recognition settings"`
+	AppriseAPI   []AppriseAPI `fig:"apprise-api" json:"apprise-api,omitempty" doc:"Apprise API notification settings"`
+	Discord      []Discord    `fig:"discord" json:"discord,omitempty" doc:"Discord notification settings"`
+	Gotify       []Gotify     `fig:"gotify" json:"gotify,omitempty" doc:"Gotify notification settings"`
+	Matrix       []Matrix     `fig:"matrix" json:"matrix,omitempty" doc:"Matrix notification settings"`
+	Mattermost   []Mattermost `fig:"mattermost" json:"mattermost,omitempty" doc:"Mattermost notification settings"`
+	Ntfy         []Ntfy       `fig:"ntfy" json:"ntfy,omitempty" doc:"Ntfy notification settings"`
+	Pushover     []Pushover   `fig:"pushover" json:"pushover,omitempty" doc:"Pushover notification settings"`
+	Signal       []Signal     `fig:"signal" json:"signal,omitempty" doc:"Signal notification settings"`
+	SMTP         []SMTP       `fig:"smtp" json:"smtp,omitempty" doc:"SMTP notification settings"`
+	Telegram     []Telegram   `fig:"telegram" json:"telegram,omitempty" doc:"Telegram notification settings"`
+	Webhook      []Webhook    `fig:"webhook" json:"webhook,omitempty" doc:"Webhook notification settings"`
 }
 
 type General struct {
@@ -77,7 +78,12 @@ type General struct {
 	NotifyDetections bool   `fig:"notify_detections,omitempty" json:"notify_detections" enum:"true,false" doc:"Enable notifications on detection (For app mode: reviews)" default:false`
 	RecheckDelay     int    `fig:"recheck_delay" json:"recheck_delay,omitempty" default:"0" doc:"Delay before re-checking event details from Frigate"`
 	AudioOnly        string `fig:"audio_only" json:"audio_only,omitempty" enum:"allow,drop" doc:"Allow/Drop events that only contain audio detections" default:"allow"`
-	WaitforLPR       bool   `fig:"wait_for_lpr" json:"wait_for_lpr,omitempty" enum:"true,false" doc:"Wait for license plate recognition when car & license plate are detected" default:false`
+}
+
+type LicensePlate struct {
+	Enabled bool     `fig:"enabled" json:"enabled,omitempty" enum:"true,false" doc:"Enable waiting for license plate recognition when car & license plate are detected" default:false`
+	Allow   []string `fig:"allow" json:"allow,omitempty" doc:"List of license plates to allow alerts from" default:[]`
+	Block   []string `fig:"block" json:"block,omitempty" doc:"List of license plates to always block" default:[]`
 }
 
 type Quiet struct {

--- a/models/config.go
+++ b/models/config.go
@@ -75,8 +75,9 @@ type General struct {
 	MaxSnapRetry     int    `fig:"max_snap_retry,omitempty" json:"max_snap_retry" doc:"Maximum number of retry attempts when snapshot is not ready yet" default:"10"`
 	NotifyOnce       bool   `fig:"notify_once,omitempty"  json:"notify_once" enum:"true,false" doc:"Only notify once per event (For app mode: events)" default:false`
 	NotifyDetections bool   `fig:"notify_detections,omitempty" json:"notify_detections" enum:"true,false" doc:"Enable notifications on detection (For app mode: reviews)" default:false`
-	RecheckDelay     int    `fig:"recheck_delay" json:"recheck_delay" default:"0" doc:"Delay before re-checking event details from Frigate"`
-	AudioOnly        string `fig:"audio_only" json:"audio_only" enum:"allow,drop" doc:"Allow/Drop events that only contain audio detections" default:"allow"`
+	RecheckDelay     int    `fig:"recheck_delay" json:"recheck_delay,omitempty" default:"0" doc:"Delay before re-checking event details from Frigate"`
+	AudioOnly        string `fig:"audio_only" json:"audio_only,omitempty" enum:"allow,drop" doc:"Allow/Drop events that only contain audio detections" default:"allow"`
+	WaitforLPR       bool   `fig:"wait_for_lpr" json:"wait_for_lpr,omitempty" enum:"true,false" doc:"Wait for license plate recognition when car & license plate are detected" default:false`
 }
 
 type Quiet struct {

--- a/models/event.go
+++ b/models/event.go
@@ -17,12 +17,16 @@ type Event struct {
 	Box    interface{} `json:"box"`
 	Camera string      `json:"camera"`
 	Data   struct {
-		Attributes []interface{} `json:"attributes"`
-		Box        []float64     `json:"box"`
-		Region     []float64     `json:"region"`
-		Score      float64       `json:"score"`
-		TopScore   float64       `json:"top_score"`
-		Type       string        `json:"type"`
+		Attributes []struct {
+			Label string `json:"label"`
+		} `json:"attributes"`
+		Box                         []float64 `json:"box"`
+		Region                      []float64 `json:"region"`
+		Score                       float64   `json:"score"`
+		TopScore                    float64   `json:"top_score"`
+		Type                        string    `json:"type"`
+		RecognizedLicensePlate      string    `json:"recognized_license_plate"`
+		RecognizedLicensePlateScore float64   `json:"recognized_license_plate_score"`
 	} `json:"data"`
 	EndTime            interface{} `json:"end_time"`
 	FalsePositive      interface{} `json:"false_positive"`
@@ -48,8 +52,10 @@ type Event struct {
 type ExtraFields struct {
 	FormattedTime       string
 	TopScorePercent     string
+	LicensePlatePercent string
 	LabelList           string
 	SubLabelList        string
+	LicensePlateList    string
 	ZoneList            string
 	LocalURL            string
 	PublicURL           string

--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -222,9 +222,10 @@ func setExtras(events []models.Event) models.Event {
 	key.Extra.LocalURL = config.ConfigData.Frigate.Server
 	key.Extra.PublicURL = config.ConfigData.Frigate.PublicURL
 
-	// Create list of all detected object (mostly applicable to /reviews)
+	// Create list of all detected objects / license plates (mostly applicable to /reviews)
 	var labelList []string
 	var sublabelList []string
+	var licenseplateList []string
 	for _, event := range events {
 		if !slices.Contains(labelList, event.Label) {
 			labelList = append(labelList, event.Label)
@@ -232,9 +233,13 @@ func setExtras(events []models.Event) models.Event {
 		if !slices.Contains(sublabelList, event.SubLabel) {
 			sublabelList = append(sublabelList, event.SubLabel)
 		}
+		if !slices.Contains(licenseplateList, event.Data.RecognizedLicensePlate) {
+			licenseplateList = append(licenseplateList, event.Data.RecognizedLicensePlate)
+		}
 	}
 	key.Extra.LabelList = strings.Join(labelList, ", ")
 	key.Extra.SubLabelList = strings.Join(sublabelList, ", ")
+	key.Extra.LicensePlateList = strings.Join(licenseplateList, ", ")
 
 	// MQTT uses CurrentZones, Web API uses Zones
 	// Combine into one object to use regardless of connection method
@@ -256,6 +261,9 @@ func setExtras(events []models.Event) models.Event {
 
 	// Calc TopScore percentage
 	key.Extra.TopScorePercent = fmt.Sprintf("%v%%", int((key.TopScore * 100)))
+
+	// Calc License Plate score percentage
+	key.Extra.LicensePlatePercent = fmt.Sprintf("%v%%", int((key.Data.RecognizedLicensePlateScore * 100)))
 
 	return key
 }

--- a/notifier/webhook.go
+++ b/notifier/webhook.go
@@ -17,6 +17,7 @@ type WebhookPayload struct {
 	ID           string   `json:"id"`
 	Camera       string   `json:"camera"`
 	Label        string   `json:"label"`
+	LicensePlate string   `json:"license_plate"`
 	SubLabel     string   `json:"sublabel"`
 	Score        string   `json:"score"`
 	Audio        string   `json:"audio"`
@@ -58,6 +59,7 @@ func SendWebhook(event models.Event, provider notifMeta) {
 			ID:           event.ID,
 			Camera:       event.Extra.CameraName,
 			Label:        event.Label,
+			LicensePlate: event.Data.RecognizedLicensePlate,
 			SubLabel:     event.SubLabel,
 			Score:        event.Extra.TopScorePercent,
 			Audio:        event.Extra.Audio,

--- a/templates/html.template
+++ b/templates/html.template
@@ -2,6 +2,7 @@ Detection at {{ .Extra.FormattedTime }} <br />
 Camera: {{ .Extra.CameraName }} <br />
 {{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }} <br /> {{ end }}
 {{ if ge (len .Extra.SubLabelList) 1 }}Sublabel(s): {{ .Extra.SubLabelList }} <br /> {{ end }}
+{{ if ge (len .Extra.LicensePlateList) 1 }}License Plate(s): {{ .Extra.LicensePlateList }} <br /> {{ end }}
 {{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }}<br /> {{ end }}
 {{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
 {{ end }}

--- a/templates/markdown.template
+++ b/templates/markdown.template
@@ -2,6 +2,7 @@ Detection at {{ .Extra.FormattedTime }}
 Camera: {{ .Extra.CameraName }}  
 {{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }} {{ end }}
 {{ if ge (len .Extra.SubLabelList) 1 }}Sublabel(s): {{ .Extra.SubLabelList }} {{ end }}
+{{ if ge (len .Extra.LicensePlateList) 1 }}License Plate(s): {{ .Extra.LicensePlateList }} {{ end }}
 {{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }} {{ end }}
 {{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
 {{ end }}

--- a/templates/plaintext.template
+++ b/templates/plaintext.template
@@ -2,6 +2,7 @@ Detection at {{ .Extra.FormattedTime }}
 Camera: {{ .Extra.CameraName }}
 {{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }} {{ end }}
 {{ if ge (len .Extra.SubLabelList) 1 }}Sublabel(s): {{ .Extra.SubLabelList }} {{ end }}
+{{ if ge (len .Extra.LicensePlateList) 1 }}License Plate(s): {{ .Extra.LicensePlateList }} {{ end }}
 {{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }} {{ end }}
 {{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
 {{ end }}


### PR DESCRIPTION
- Add `recognized_license_plate` field to event data
- Add license plate detail into notification templates
- Add ability to wait for license plate data from Frigate
  - In testing, most were available within ~3-5 seconds
  - Frigate-notify will wait up to 10 seconds
- Add ability to allow / block license plates from notifications 

resolves #244  