### PR TITLE
fix: check if downloaded clip is empty

### DIFF
--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -237,7 +237,20 @@ func GetClip(event models.Event) io.Reader {
 					Msgf("Could not access clip")
 				return nil
 			}
+		} else if len(response) == 0 {
+			// Frigate is probably still processing the clip
+			// Wait a bit and try again
+			attempts += 1
+			time.Sleep(2 * time.Second)
+			log.Info().
+				Str("event_id", event.ID).
+				Int("attempt", attempts).
+				Int("max_attempts", max_attempts).
+				Msgf("Waiting for clip to be available")
 		} else {
+			log.Debug().
+				Str("event_id", event.ID).
+				Msgf("Clip available")
 			break
 		}
 	}


### PR DESCRIPTION
This pull request enhances the `GetClip` function in `notifier/alerts.go` to improve handling of scenarios where a clip is not immediately available. The most important change introduces a retry mechanism with logging to wait for the clip to be processed.

### Improvements to clip retrieval:

* [`notifier/alerts.go`](diffhunk://#diff-6c7785c677e6f734e3d5fc0e1d1ac809e5da51394255d2f8ca982755de92221bR240-R253): Added a retry mechanism to handle cases where the clip is still being processed by Frigate. This includes waiting for 2 seconds between attempts, incrementing the attempt counter, and logging the retry status. A debug log is also added to indicate when the clip becomes available.

### Before
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/df56fdfd-ea51-479c-8174-360fc0df63e9" />

### After
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/ddda4e34-8348-485c-a5a4-8b229caeea32" />
