### PR TITLE
[gotify] make message priority configurable

### DIFF
--- a/models/config.go
+++ b/models/config.go
@@ -141,6 +141,7 @@ type Gotify struct {
 	Server      string `koanf:"server" json:"server,omitempty" doc:"Gotify server URL" default:""`
 	Token       string `koanf:"token" json:"token,omitempty" doc:"Gotify app token" default:""`
 	Insecure    bool   `koanf:"ignoressl" json:"ignoressl,omitempty" doc:"Ignore TLS/SSL errors" default:"false"`
+	Priority    int    `koanf:"priority" json:"priority,omitempty" minimum:"0" maximum:"10" doc:"Gotify message priority" default:"5"`
 }
 
 type Matrix struct {

--- a/notifier/gotify.go
+++ b/notifier/gotify.go
@@ -65,7 +65,7 @@ func SendGotifyPush(event models.Event, provider notifMeta) {
 	payload := gotifyPayload{
 		Message:  message,
 		Title:    title,
-		Priority: 5,
+		Priority: config.ConfigData.Alerts.Gotify[provider.index].Priority,
 	}
 	payload.Extras.ClientDisplay.ContentType = "text/markdown"
 	payload.Extras.ClientNotification.BigImageURL = snapshotURL


### PR DESCRIPTION
I know you can set notification behavior on a per-app per-priority level in android notification settings, but for consistency I wanted to be able to indicate that detecting a human on my NVR was a high priority thing. Opens the door later to set priority based on detected object type (which i am far too lazy to do right now).