### PR TITLE
Remove blank lines from default templates

### DIFF
--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -2,9 +2,9 @@ package notifier
 
 import (
 	"bytes"
-	"embed"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"slices"
@@ -21,7 +21,7 @@ import (
 	"github.com/0x2142/frigate-notify/util"
 )
 
-var TemplateFiles embed.FS
+var TemplateFiles fs.FS
 
 type notifMeta struct {
 	name  string

--- a/notifier/alerts_test.go
+++ b/notifier/alerts_test.go
@@ -1,0 +1,121 @@
+package notifier
+
+import (
+	"os"
+	"testing"
+
+	"github.com/0x2142/frigate-notify/models"
+)
+
+func TestMain(m *testing.M) {
+	TemplateFiles = os.DirFS("..")
+	os.Exit(m.Run())
+}
+
+func TestRenderMessage(t *testing.T) {
+	emptyEvent := models.Event{}
+	fullEvent := models.Event{
+		Camera:      "front_door",
+		HasSnapshot: true,
+		HasClip:     true,
+		Zones:       []string{"driveway", "entryway"},
+		Extra: models.ExtraFields{
+			FormattedTime:       "2026-06-20 15:04:05 +0000",
+			CameraName:          "Front Door",
+			LabelList:           "person, dog",
+			SubLabelList:        "visitor",
+			LicensePlateList:    "ABC123",
+			Audio:               "speech",
+			ZoneList:            "driveway, entryway",
+			PublicURL:           "https://frigate.example",
+			FrigateMajorVersion: 17,
+			ReviewLink:          "https://frigate.example/review/evt-1",
+			EventLink:           "https://frigate.example/api/events/evt-1/clip.mp4",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		template string
+		event    models.Event
+		expected string
+	}{
+		{
+			name:     "html empty event",
+			template: "html",
+			event:    emptyEvent,
+			expected: "Detection at <br />\n" +
+				"Camera: <br />\n" +
+				"Links: <a href=\"/cameras/\">Camera</a>\n" +
+				"<br /><br />No snapshot available.",
+		},
+		{
+			name:     "html full event",
+			template: "html",
+			event:    fullEvent,
+			expected: "Detection at 2026-06-20 15:04:05 +0000<br />\n" +
+				"Camera: Front Door<br />\n" +
+				"Label(s): person, dog<br />\n" +
+				"Sublabel(s): visitor<br />\n" +
+				"License Plate(s): ABC123<br />\n" +
+				"Audio: speech<br />\n" +
+				"Zone(s): driveway, entryway<br />\n" +
+				"Links: <a href=\"https://frigate.example/#front_door\">Camera</a> | <a href=\"https://frigate.example/review/evt-1\">Review Event</a>",
+		},
+		{
+			name:     "markdown empty event",
+			template: "markdown",
+			event:    emptyEvent,
+			expected: "Detection at   \n" +
+				"Camera: \n" +
+				"Links: [Camera](/cameras/)\n" +
+				"\nNo snapshot available.",
+		},
+		{
+			name:     "markdown full event",
+			template: "markdown",
+			event:    fullEvent,
+			expected: "Detection at 2026-06-20 15:04:05 +0000  \n" +
+				"Camera: Front Door\n" +
+				"Label(s): person, dog\n" +
+				"Sublabel(s): visitor\n" +
+				"License Plate(s): ABC123\n" +
+				"Audio: speech\n" +
+				"Zone(s): driveway, entryway\n" +
+				"Links: [Camera](https://frigate.example/#front_door) | [Review Event](https://frigate.example/review/evt-1)",
+		},
+		{
+			name:     "plaintext empty event",
+			template: "plaintext",
+			event:    emptyEvent,
+			expected: "Detection at \n" +
+				"Camera: \n" +
+				"Links: - Camera: /cameras/\n" +
+				"\nNo snapshot available.",
+		},
+		{
+			name:     "plaintext full event",
+			template: "plaintext",
+			event:    fullEvent,
+			expected: "Detection at 2026-06-20 15:04:05 +0000\n" +
+				"Camera: Front Door\n" +
+				"Label(s): person, dog\n" +
+				"Sublabel(s): visitor\n" +
+				"License Plate(s): ABC123\n" +
+				"Audio: speech\n" +
+				"Zone(s): driveway, entryway\n" +
+				"Links:\n" +
+				" - Camera: https://frigate.example/#front_door\n" +
+				" - Review Event: https://frigate.example/review/evt-1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := renderMessage(test.template, test.event, "message", "test")
+			if result != test.expected {
+				t.Errorf("Expected: %q, Got: %q", test.expected, result)
+			}
+		})
+	}
+}

--- a/templates/html.template
+++ b/templates/html.template
@@ -1,12 +1,21 @@
 Detection at {{ .Extra.FormattedTime }}<br />
 Camera: {{ .Extra.CameraName }}<br />
-{{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }}<br />{{ end }}
-{{ if ge (len .Extra.SubLabelList) 1 }}Sublabel(s): {{ .Extra.SubLabelList }}<br />{{ end }}
-{{ if ge (len .Extra.LicensePlateList) 1 }}License Plate(s): {{ .Extra.LicensePlateList }}<br />{{ end }}
-{{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }}<br />{{ end }}
-{{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
-{{ end }}
-<br />
+{{- if ge (len .Extra.LabelList) 1 }}
+Label(s): {{ .Extra.LabelList }}<br />
+{{- end }}
+{{- if ge (len .Extra.SubLabelList) 1 }}
+Sublabel(s): {{ .Extra.SubLabelList }}<br />
+{{- end }}
+{{- if ge (len .Extra.LicensePlateList) 1 }}
+License Plate(s): {{ .Extra.LicensePlateList }}<br />
+{{- end }}
+{{- if ge (len .Extra.Audio) 1 }}
+Audio: {{ .Extra.Audio }}<br />
+{{- end }}
+{{- if ge (len .Zones) 1 }}
+Zone(s): {{ .Extra.ZoneList }}<br />
+{{- end }}
 Links: <a href="{{if ge .Extra.FrigateMajorVersion 14 }}{{ .Extra.PublicURL }}/#{{ .Camera }}{{ else }}{{ .Extra.PublicURL }}/cameras/{{ .Camera }}{{ end }}">Camera</a>{{ if ne .Extra.ReviewLink "" }} | <a href="{{ .Extra.ReviewLink }}">Review Event</a>{{ else }}{{ if .HasClip }} | <a href="{{ .Extra.EventLink }}">Event Clip</a> <br />{{ end }}{{ end }}
-{{ if not .HasSnapshot }}<br /><br />No snapshot available.
-{{ end }}
+{{- if not .HasSnapshot }}
+<br /><br />No snapshot available.
+{{- end }}

--- a/templates/markdown.template
+++ b/templates/markdown.template
@@ -1,12 +1,22 @@
 Detection at {{ .Extra.FormattedTime }}  
 Camera: {{ .Extra.CameraName }}  
-{{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }} {{ end }}
-{{ if ge (len .Extra.SubLabelList) 1 }}Sublabel(s): {{ .Extra.SubLabelList }} {{ end }}
-{{ if ge (len .Extra.LicensePlateList) 1 }}License Plate(s): {{ .Extra.LicensePlateList }} {{ end }}
-{{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }} {{ end }}
-{{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
-{{ end }}
+{{- if ge (len .Extra.LabelList) 1 }}
+Label(s): {{ .Extra.LabelList }} 
+{{- end }}
+{{- if ge (len .Extra.SubLabelList) 1 }}
+Sublabel(s): {{ .Extra.SubLabelList }} 
+{{- end }}
+{{- if ge (len .Extra.LicensePlateList) 1 }}
+License Plate(s): {{ .Extra.LicensePlateList }} 
+{{- end }}
+{{- if ge (len .Extra.Audio) 1 }}
+Audio: {{ .Extra.Audio }} 
+{{- end }}
+{{- if ge (len .Zones) 1 }}
+Zone(s): {{ .Extra.ZoneList }}
+{{- end }}
 Links: [Camera]({{if ge .Extra.FrigateMajorVersion 14 }}{{ .Extra.PublicURL }}/#{{ .Camera }}{{ else }}{{ .Extra.PublicURL }}/cameras/{{ .Camera }}{{ end }}){{if ne .Extra.ReviewLink "" }} | [Review Event]({{ .Extra.ReviewLink }}){{else}}{{ if .HasClip }} | [Event Clip]({{ .Extra.EventLink }}){{ end }}{{ end }}
+{{- if not .HasSnapshot }}
 
-{{ if not .HasSnapshot }}No snapshot available.  {{end}}
-
+No snapshot available.
+{{- end}}

--- a/templates/plaintext.template
+++ b/templates/plaintext.template
@@ -1,13 +1,28 @@
 Detection at {{ .Extra.FormattedTime }}
-Camera: {{ .Extra.CameraName }}
-{{ if ge (len .Extra.LabelList) 1 }}Label(s): {{ .Extra.LabelList }} {{ end }}
-{{ if ge (len .Extra.SubLabelList) 1 }}Sublabel(s): {{ .Extra.SubLabelList }} {{ end }}
-{{ if ge (len .Extra.LicensePlateList) 1 }}License Plate(s): {{ .Extra.LicensePlateList }} {{ end }}
-{{ if ge (len .Extra.Audio) 1 }}Audio: {{ .Extra.Audio }} {{ end }}
-{{ if ge (len .Zones) 1 }}Zone(s): {{ .Extra.ZoneList }}
-{{ end }}
+Camera: {{ .Extra.CameraName }}  
+{{- if ge (len .Extra.LabelList) 1 }}
+Label(s): {{ .Extra.LabelList }} 
+{{- end }}
+{{- if ge (len .Extra.SubLabelList) 1 }}
+Sublabel(s): {{ .Extra.SubLabelList }} 
+{{- end }}
+{{- if ge (len .Extra.LicensePlateList) 1 }}
+License Plate(s): {{ .Extra.LicensePlateList }} 
+{{- end }}
+{{- if ge (len .Extra.Audio) 1 }}
+Audio: {{ .Extra.Audio }} 
+{{- end }}
+{{- if ge (len .Zones) 1 }}
+Zone(s): {{ .Extra.ZoneList }}
+{{- end }}
 Links:
-{{if ge .Extra.FrigateMajorVersion 14 }} - Camera: {{ .Extra.PublicURL }}/#{{ .Camera }}{{else}} - Camera: {{ .Extra.PublicURL }}/cameras/{{ .Camera }}{{end}}
-{{if ne .Extra.ReviewLink ""}} - Review Event: {{ .Extra.ReviewLink }}{{ else }}{{ if .HasClip }} - Event Clip: {{ .Extra.EventLink }}{{ end }}{{ end }}
+{{- if ge .Extra.FrigateMajorVersion 14 }}
+ - Camera: {{ .Extra.PublicURL }}/#{{ .Camera }}{{else}} - Camera: {{ .Extra.PublicURL }}/cameras/{{ .Camera }}
+{{- end}}
+{{- if ne .Extra.ReviewLink ""}}
+ - Review Event: {{ .Extra.ReviewLink }}{{ else }}{{ if .HasClip }} - Event Clip: {{ .Extra.EventLink }}{{ end }}
+{{- end }}
+{{- if not .HasSnapshot }}
 
-{{ if not .HasSnapshot }}No snapshot available.{{end}}
+No snapshot available.
+{{- end}}


### PR DESCRIPTION
First of all, thanks for this awesome notifier.

I hade some blank lines in my notifications while using the default templates.
<img width="447" height="226" alt="image" src="https://github.com/user-attachments/assets/fa68ddec-7b5a-41f2-bedf-0029be99c94d" />

This PR should remove them.