### PR TITLE
fix: add Sublabel template alias and fix Matrix body rendering

### DIFF
--- a/models/event.go
+++ b/models/event.go
@@ -40,6 +40,7 @@ type Event struct {
 	RetainIndefinitely bool        `json:"retain_indefinitely"`
 	StartTime          float64     `json:"start_time"`
 	SubLabel           string      `json:"sub_label"`
+	Sublabel           string      // Alias for SubLabel, accessible via templates as .Sublabel
 	Thumbnail          string      `json:"thumbnail"`
 	TopScore           float64     `json:"top_score"`
 	Zones              []string    `json:"zones"`

--- a/notifier/alerts.go
+++ b/notifier/alerts.go
@@ -280,6 +280,9 @@ func setExtras(events []models.Event) models.Event {
 	caser := cases.Title(language.Und)
 	key.Extra.CameraName = caser.String(strings.ReplaceAll(key.Camera, "_", " "))
 
+	// Set Sublabel alias for backward compatibility with templates
+	key.Sublabel = key.SubLabel
+
 	// Assign Frigate URL to extra event fields
 	key.Extra.LocalURL = config.ConfigData.Frigate.Server
 	key.Extra.PublicURL = config.ConfigData.Frigate.PublicURL

--- a/notifier/matrix.go
+++ b/notifier/matrix.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -115,7 +116,8 @@ func SendMatrix(event models.Event, snapshot io.Reader, provider notifMeta) {
 	_, err = m.SendMessageEvent(context.Background(), id.RoomID(profile.RoomID), evt.EventMessage, &evt.MessageEventContent{
 		MsgType:       evt.MsgText,
 		Format:        "org.matrix.custom.html",
-		FormattedBody: message,
+		Body:          message,
+		FormattedBody: strings.ReplaceAll(message, "\n", "<br>"),
 	})
 	if err != nil {
 		log.Warn().


### PR DESCRIPTION
Fixes #381 #372

```release-notes
[BUGFIX] templates: Add Sublabel field alias for backward compatibility with custom templates
[BUGFIX] matrix: Populate Body field and convert \n to <br> tags in Matrix messages
```