### PR TITLE
fix: populate Matrix body field and format newlines

### DIFF
--- a/notifier/matrix.go
+++ b/notifier/matrix.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -112,10 +113,15 @@ func SendMatrix(event models.Event, snapshot io.Reader, provider notifMeta) {
 	}
 
 	// Send event details
-	_, err = m.SendMessageEvent(context.Background(), id.RoomID(profile.RoomID), evt.EventMessage, &evt.MessageEventContent{
+	formattedBody := message
+	// Convert newline characters to HTML line breaks for proper rendering
+	formattedBody = strings.ReplaceAll(formattedBody, "\n", "<br>")
+
+	_, err = m.SendMessageEvent(context.Background(), id.RoomID(profile.RoomID), evt.EventMessage, &evt.MessageEventContent{\
 		MsgType:       evt.MsgText,
 		Format:        "org.matrix.custom.html",
-		FormattedBody: message,
+		Body:          message,
+		FormattedBody: formattedBody,
 	})
 	if err != nil {
 		log.Warn().


### PR DESCRIPTION
Fixes #372

Matrix notifications sent by frigate-notify have an empty 'body' field in
m.room.message events. According to the Matrix spec, body must always contain
a plaintext fallback.

Also converts newline characters to <br> tags in formatted_body for proper
HTML rendering in clients like Element X.