### PR TITLE
Alert when sublabel is classified, avoid race condition

### DIFF
--- a/events/cache.go
+++ b/events/cache.go
@@ -73,14 +73,13 @@ func zoneAlreadyAlerted(event models.Event) bool {
 		Strs("cache", alreadyAlerted).
 		Str("event_id", event.ID).
 		Msgf("Get event from cache")
-	// If event not found, create cache entry & add zones
+	// If event not found, allow it through (cache is populated later, after all filters pass)
 	if !ok {
 		log.Debug().
 			Str("event_id", event.ID).
 			Str("camera", event.Camera).
 			Str("zones", strings.Join(event.CurrentZones, ",")).
-			Msg("Event not in cache, adding...")
-		setZoneAlerted(event)
+			Msg("Event not in cache, proceeding with filter checks")
 		return false
 	}
 	// If event found, check to see if there are any new zones to notify on
@@ -91,7 +90,6 @@ func zoneAlreadyAlerted(event models.Event) bool {
 				Str("camera", event.Camera).
 				Str("zones", strings.Join(event.CurrentZones, ",")).
 				Msg("Found new zone not in cache")
-			setZoneAlerted(event)
 			return false
 		}
 	}

--- a/events/events.go
+++ b/events/events.go
@@ -47,6 +47,9 @@ func processEvent(event models.Event) {
 		return
 	}
 
+	// Event passed all filters - now mark zone as alerted in cache
+	setZoneAlerted(event)
+
 	// Send alert with snapshot
 	notifier.SendAlert([]models.Event{event})
 }

--- a/events/reviews.go
+++ b/events/reviews.go
@@ -101,6 +101,9 @@ func processReview(review models.Review) {
 			break
 		}
 
+		// Event passed all filters - now mark zone as alerted in cache
+		setZoneAlerted(detection)
+
 		// Add special link to review page
 		detection.Extra.ReviewLink = config.ConfigData.Frigate.PublicURL + "/review?id=" + review.ID
 


### PR DESCRIPTION
When Frigate sends a detection event, the sublabel is often not yet assigned as the classification model runs asynchronously.

frigate-notify evaluates the sublabel allow list immediately, often finds an empty sublabel, and drops the event;

however, it also caches the event ID in the zone cache at that point.

when Frigate later updates the review with the sublabel populated, frigate-notify sees the event ID already in the zone cache and drops it as "Already notified on this zone" even though no notification was ever sent.